### PR TITLE
Worked around ambiguity in C++ for fgIsA and std::atomic<>

### DIFF
--- a/cint/reflex/python/genreflex/gendict.py
+++ b/cint/reflex/python/genreflex/gendict.py
@@ -2819,6 +2819,10 @@ def ClassDefImplementation(selclasses, self) :
       returnValue += '      b.WriteClassBuffer(' + clname  + '::Class(),this);\n'
       returnValue += '   }\n'
       returnValue += '}\n'
+      #must strip of leading '::' to avoid ambiguity with embedded type in atomic_TClass_ptr
+      if len(specclname) > 2:
+        if specclname[:2] == '::':
+          specclname = specclname[2:]        
       returnValue += template + 'atomic_TClass_ptr ' + specclname + '::fgIsA(0);\n'
       returnValue += namespacelevel * '}' + '\n'
     elif derivesFromTObject :


### PR DESCRIPTION
The code created by genreflex was including the default namespace
qualifyer '::' on all class names. However, this lead to a C++
language ambiguity when parsing
   std::atomic<TClass*> ::Foo::fgIsA = 0
where the parser treats that as being
   std::atomic<TClass*>::Foo::fgIsA = 0
and fails since Foo is not a type defined in std::atomic<>.
The fix was to remove the '::' when generating the code. This then
matches what Cint does when generating the code.
