### PR TITLE
Make gCintMutex and gROOTMutex use the same mutex

### DIFF
--- a/core/thread/src/TThread.cxx
+++ b/core/thread/src/TThread.cxx
@@ -300,6 +300,16 @@ void TThread::Init()
    gGlobalMutex = new TMutex(kTRUE);
    gCint->SetAlloclockfunc(CINT_alloc_lock);
    gCint->SetAllocunlockfunc(CINT_alloc_unlock);
+
+   //To avoid deadlocks, gCintMutex and gROOTMutex need
+   // to point at the same instance
+   {
+     R__LOCKGUARD(gGlobalMutex);
+     if (!gCINTMutex) {
+       gCINTMutex = gGlobalMutex->Factory(kTRUE);
+     }
+     gROOTMutex = gCINTMutex;
+   }
 }
 
 //______________________________________________________________________________


### PR DESCRIPTION
In order to avoid deadlocking, the variables gCintMutex and
gROOTMutex now point to the same underlying mutex. The mutex is
also created when TThread::Init() is first called rather than doing
it lazily.
