### PR TITLE
Make TMVA thread-safe with respect to use of Reader

### DIFF
--- a/tmva/inc/TMVA/BDTEventWrapper.h
+++ b/tmva/inc/TMVA/BDTEventWrapper.h
@@ -67,7 +67,11 @@ namespace TMVA {
     
    private:
 
+#if __cplusplus > 199711L
+      static thread_local Int_t fVarIndex;  // index of the variable to sort on
+#else
       static Int_t fVarIndex;  // index of the variable to sort on
+#endif
       const Event* fEvent;     // pointer to the event
     
       Double_t     fBkgWeight; // cumulative background weight for splitting

--- a/tmva/inc/TMVA/BinaryTree.h
+++ b/tmva/inc/TMVA/BinaryTree.h
@@ -123,8 +123,7 @@ namespace TMVA {
       UInt_t     fNNodes;           // total number of nodes in the tree (counted)
       UInt_t     fDepth;            // maximal depth in tree reached
 
-      static MsgLogger* fgLogger;   // message logger, static to save resources    
-      MsgLogger& Log() const { return *fgLogger; }
+      MsgLogger& Log() const;
 
       ClassDef(BinaryTree,0) // Base class for BinarySearch and Decision Trees
    };  

--- a/tmva/inc/TMVA/Config.h
+++ b/tmva/inc/TMVA/Config.h
@@ -36,7 +36,9 @@
 // Singleton class for global configuration settings used by TMVA       //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
-
+#if __cplusplus > 199711L
+#include <atomic>
+#endif
 #ifndef ROOT_Rtypes
 #include "Rtypes.h"
 #endif
@@ -103,16 +105,27 @@ namespace TMVA {
 
       // private constructor
       Config();
+      Config( const Config& );
+      Config& operator=( const Config&);
       virtual ~Config();
+#if __cplusplus > 199711L
+      static std::atomic<Config*> fgConfigPtr;
+#else
       static Config* fgConfigPtr;
-                  
+#endif                  
    private:
 
+#if __cplusplus > 199711L
+      std::atomic<Bool_t> fUseColoredConsole;     // coloured standard output
+      std::atomic<Bool_t> fSilent;                // no output at all
+      std::atomic<Bool_t> fWriteOptionsReference; // if set true: Configurable objects write file with option reference
+      std::atomic<Bool_t> fDrawProgressBar;       // draw progress bar to indicate training evolution
+#else
       Bool_t fUseColoredConsole;     // coloured standard output
       Bool_t fSilent;                // no output at all
       Bool_t fWriteOptionsReference; // if set true: Configurable objects write file with option reference
       Bool_t fDrawProgressBar;       // draw progress bar to indicate training evolution
-
+#endif
       mutable MsgLogger* fLogger;   // message logger
       MsgLogger& Log() const { return *fLogger; }
          

--- a/tmva/inc/TMVA/DataSetFactory.h
+++ b/tmva/inc/TMVA/DataSetFactory.h
@@ -254,6 +254,8 @@ namespace TMVA {
 
       DataSet* CreateDataSet( DataSetInfo &, DataInputHandler& );
 
+      static DataSetFactory* NewInstance() { return new DataSetFactory(); }
+      static void destroyNewInstance(DataSetFactory* iOther) { delete iOther;}
    protected:
 
       ~DataSetFactory();
@@ -314,8 +316,8 @@ namespace TMVA {
       Bool_t                     fScaleWithPreselEff; //! how to deal with requested #events in connection with preselection cuts 
 
       // the event
-      mutable TTree*             fCurrentTree;       //! the tree, events are currently read from
-      mutable UInt_t             fCurrentEvtIdx;     //! the current event (to avoid reading of the same event)
+      TTree*                     fCurrentTree;       //! the tree, events are currently read from
+      UInt_t                     fCurrentEvtIdx;     //! the current event (to avoid reading of the same event)
 
       // the formulas for reading the original tree
       std::vector<TTreeFormula*> fInputFormulas;   //! input variables
@@ -324,7 +326,7 @@ namespace TMVA {
       std::vector<TTreeFormula*> fWeightFormula;   //! weights
       std::vector<TTreeFormula*> fSpectatorFormulas; //! spectators
 
-      mutable MsgLogger*         fLogger;          //! message logger
+      MsgLogger*                 fLogger;          //! message logger
       MsgLogger& Log() const { return *fLogger; }
    };
 }

--- a/tmva/inc/TMVA/DataSetManager.h
+++ b/tmva/inc/TMVA/DataSetManager.h
@@ -84,14 +84,14 @@ namespace TMVA {
 /*       DataSetManager(); */ // DSMTEST
 /*       DataSetManager( DataInputHandler& dataInput ); */ // DSMTEST
 
-// //      TMVA::DataSetFactory* fDatasetFactory; // DSMTEST
+      TMVA::DataSetFactory* fDatasetFactory;
 
       // access to input data
       DataInputHandler& DataInput() { return fDataInput; }
 
       DataInputHandler&          fDataInput;             //! source of input data
       TList                      fDataSetInfoCollection; //! all registered dataset definitions
-      mutable MsgLogger*         fLogger;   // message logger
+      MsgLogger*                 fLogger;   // message logger
       MsgLogger& Log() const { return *fLogger; }    
    };
 }

--- a/tmva/inc/TMVA/DecisionTreeNode.h
+++ b/tmva/inc/TMVA/DecisionTreeNode.h
@@ -354,7 +354,7 @@ namespace TMVA {
 
    protected:
 
-      static MsgLogger* fgLogger;    // static because there is a huge number of nodes...
+      static MsgLogger& Log();
 
       std::vector<Double_t>       fFisherCoeff;    // the fisher coeff (offset at the last element)
 

--- a/tmva/inc/TMVA/Interval.h
+++ b/tmva/inc/TMVA/Interval.h
@@ -90,8 +90,7 @@ namespace TMVA {
       Int_t    fNbins;        // when >0 : number of bins (discrete interval); when ==0 continuous interval
 
    private:
-      static MsgLogger* fgLogger;   // message logger
-      MsgLogger& Log() const { return *fgLogger; }          
+      MsgLogger& Log() const;          
 
       ClassDef(Interval,0)    // Interval definition, continous and discrete
    };

--- a/tmva/inc/TMVA/LogInterval.h
+++ b/tmva/inc/TMVA/LogInterval.h
@@ -105,8 +105,7 @@ namespace TMVA {
       void SetMax( Double_t m ) { fMax = m; }
       void SetMin( Double_t m ) { fMin = m; }
 
-      static MsgLogger* fgLogger;   // message logger
-      MsgLogger& Log() const { return *fgLogger; }          
+      MsgLogger& Log() const;
 
       ClassDef(Interval,0)    // Interval definition, continous and discrete
    };

--- a/tmva/inc/TMVA/MethodBase.h
+++ b/tmva/inc/TMVA/MethodBase.h
@@ -629,8 +629,11 @@ namespace TMVA {
    private:
 
       // this carrier
+#if __cplusplus > 199711L
+      static thread_local MethodBase* fgThisBase;         // this pointer
+#else
       static MethodBase* fgThisBase;         // this pointer
-
+#endif
 
       // ===== depreciated options, kept for backward compatibility  =====
    private:

--- a/tmva/inc/TMVA/MethodCFMlpANN_Utils.h
+++ b/tmva/inc/TMVA/MethodCFMlpANN_Utils.h
@@ -99,12 +99,12 @@ namespace TMVA {
 
    protected:
 
-      static Int_t       fg_100;          // constant
-      static Int_t       fg_0;            // constant
-      static Int_t       fg_max_nVar_;    // static maximum number of input variables
-      static Int_t       fg_max_nNodes_;  // maximum number of nodes per variable
-      static Int_t       fg_999;          // constant
-      static const char* fg_MethodName;   // method name for print
+      static Int_t             fg_100;          // constant
+      static Int_t             fg_0;            // constant
+      static const Int_t       fg_max_nVar_;    // static maximum number of input variables
+      static const Int_t       fg_max_nNodes_;  // maximum number of nodes per variable
+      static Int_t             fg_999;          // constant
+      static const char* const fg_MethodName;   // method name for print
 
       Double_t W_ref(const Double_t wNN[], Int_t a_1, Int_t a_2, Int_t a_3) const {
          return wNN [(a_3*max_nNodes_ + a_2)*max_nLayers_ + a_1 - 187];

--- a/tmva/inc/TMVA/MethodPDERS.h
+++ b/tmva/inc/TMVA/MethodPDERS.h
@@ -220,7 +220,11 @@ namespace TMVA {
                                  Float_t sumW2S, Float_t sumW2B ) const;
 
       // this carrier
+#if __cplusplus > 199711L
+      static thread_local MethodPDERS* fgThisPDERS; // this pointer (required by root finder)
+#else
       static MethodPDERS* fgThisPDERS; // this pointer (required by root finder)
+#endif
       void UpdateThis();
 
       void Init( void );

--- a/tmva/inc/TMVA/ModulekNN.h
+++ b/tmva/inc/TMVA/ModulekNN.h
@@ -148,8 +148,11 @@ namespace TMVA {
 
       private:
 
+#if __cplusplus > 199711L
+         static thread_local TRandom3 fgRndm;
+#else
          static TRandom3 fgRndm;
-
+#endif
          UInt_t fDimn;
 
          Node<Event> *fTree;

--- a/tmva/inc/TMVA/MsgLogger.h
+++ b/tmva/inc/TMVA/MsgLogger.h
@@ -43,6 +43,9 @@
 #include <sstream>
 #include <iostream>
 #include <map>
+#if __cplusplus > 199711L
+#include <atomic>
+#endif
 
 // ROOT include(s)
 #ifndef ROOT_TObject
@@ -75,7 +78,7 @@ namespace TMVA {
       std::string GetPrintedSource()   const;
       std::string GetFormattedSource() const;
 
-      static UInt_t GetMaxSourceSize()                    { return (UInt_t)fgMaxSourceSize; }
+      static UInt_t GetMaxSourceSize()                    { return (const UInt_t)fgMaxSourceSize; }
 
       // Needed for copying
       MsgLogger& operator= ( const MsgLogger& parent );
@@ -113,13 +116,20 @@ namespace TMVA {
       static const std::string fgPrefix;          // the prefix of the source name
       static const std::string fgSuffix;          // suffix following source name
       EMsgType                 fActiveType;       // active type
-      static UInt_t            fgMaxSourceSize;   // maximum length of source name
+      static const UInt_t      fgMaxSourceSize;   // maximum length of source name
+#if __cplusplus > 199711L
+      static std::atomic<Bool_t> fgOutputSupressed; // disable the output globaly (used by generic booster)
+      static std::atomic<Bool_t> fgInhibitOutput;   // flag to suppress all output
+
+      static std::atomic<const std::map<EMsgType, std::string>*> fgTypeMap;   // matches output types with strings
+      static std::atomic<const std::map<EMsgType, std::string>*> fgColorMap;  // matches output types with terminal colors
+#else
       static Bool_t            fgOutputSupressed; // disable the output globaly (used by generic booster)
       static Bool_t            fgInhibitOutput;   // flag to suppress all output
-      static Int_t             fgInstanceCounter; // counts open MsgLogger instances
 
-      static std::map<EMsgType, std::string>* fgTypeMap;   // matches output types with strings
-      static std::map<EMsgType, std::string>* fgColorMap;  // matches output types with terminal colors
+      static const std::map<EMsgType, std::string>* fgTypeMap;   // matches output types with strings
+      static const std::map<EMsgType, std::string>* fgColorMap;  // matches output types with terminal colors
+#endif
       EMsgType                                fMinType;    // minimum type for output
 
       ClassDef(MsgLogger,0) // Ostringstream derivative to redirect and format logging output

--- a/tmva/inc/TMVA/Option.h
+++ b/tmva/inc/TMVA/Option.h
@@ -93,8 +93,7 @@ namespace TMVA {
 
    protected:
 
-      static MsgLogger* fgLogger;  // message logger
-
+      static MsgLogger& Log();
    };
       
    // ---------------------------------------------------------------------------
@@ -249,16 +248,16 @@ namespace TMVA {
    inline void TMVA::Option<Bool_t>::AddPreDefVal( const Bool_t& ) 
    {
       // template specialization for Bool_t 
-      *fgLogger << kFATAL << "<AddPreDefVal> predefined values for Option<Bool_t> don't make sense" 
-                << Endl;
+      Log() << kFATAL << "<AddPreDefVal> predefined values for Option<Bool_t> don't make sense" 
+	    << Endl;
    }
 
    template<>
    inline void TMVA::Option<Float_t>::AddPreDefVal( const Float_t& ) 
    {
       // template specialization for Float_t 
-      *fgLogger << kFATAL << "<AddPreDefVal> predefined values for Option<Float_t> don't make sense" 
-                << Endl;
+      Log() << kFATAL << "<AddPreDefVal> predefined values for Option<Float_t> don't make sense" 
+	    << Endl;
    }
 
    template<class T>
@@ -358,8 +357,8 @@ namespace TMVA {
          this->Value() = false;
       }
       else {
-         *fgLogger << kFATAL << "<SetValueLocal> value \'" << val 
-                   << "\' can not be interpreted as boolean" << Endl;
+         Log() << kFATAL << "<SetValueLocal> value \'" << val 
+	       << "\' can not be interpreted as boolean" << Endl;
       }
    }
 }

--- a/tmva/inc/TMVA/PDF.h
+++ b/tmva/inc/TMVA/PDF.h
@@ -205,7 +205,11 @@ namespace TMVA {
       MsgLogger&               Log() const { return *fLogger; }    
 
       // static pointer to this object
+#if __cplusplus > 199711L
+      static thread_local PDF* fgThisPDF;             // this PDF pointer 
+#else
       static PDF*              fgThisPDF;             // this PDF pointer 
+#endif
       static PDF*              ThisPDF( void ); 
 
       // external auxiliary functions 

--- a/tmva/inc/TMVA/TNeuron.h
+++ b/tmva/inc/TMVA/TNeuron.h
@@ -163,8 +163,7 @@ namespace TMVA {
       TActivation*  fActivation;              // activation equation
       TNeuronInput* fInputCalculator;         // input calculator
 
-      static MsgLogger* fgLogger;                     //! message logger, static to save resources
-      MsgLogger& Log() const { return *fgLogger; }                       
+      MsgLogger& Log() const;
 
       ClassDef(TNeuron,0) // Neuron class used by MethodANNBase derivative ANNs
    };

--- a/tmva/inc/TMVA/TSynapse.h
+++ b/tmva/inc/TMVA/TSynapse.h
@@ -102,8 +102,7 @@ namespace TMVA {
       TNeuron* fPreNeuron;         // pointer to pre-neuron
       TNeuron* fPostNeuron;        // pointer to post-neuron
 
-      static MsgLogger* fgLogger;                     //! message logger, static to save resources
-      MsgLogger& Log() const { return *fgLogger; }                       
+      MsgLogger& Log() const;
 
       ClassDef(TSynapse,0) // Synapse class used by MethodANNBase and derivatives
    };

--- a/tmva/inc/TMVA/Tools.h
+++ b/tmva/inc/TMVA/Tools.h
@@ -41,6 +41,9 @@
 #include <sstream>
 #include <iostream>
 #include <iomanip>
+#if __cplusplus > 199711L
+#include <atomic>
+#endif
 
 #ifndef ROOT_TXMLEngine
 #include "TXMLEngine.h"
@@ -238,7 +241,11 @@ namespace TMVA {
       const TString fRegexp;
       mutable MsgLogger*    fLogger;
       MsgLogger& Log() const { return *fLogger; }
+#if __cplusplus > 199711L
+      static std::atomic<Tools*> fgTools;
+#else
       static Tools* fgTools;
+#endif
 
       // xml tools
 

--- a/tmva/inc/TMVA/Types.h
+++ b/tmva/inc/TMVA/Types.h
@@ -38,6 +38,9 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include <map>
+#if __cplusplus > 199711L
+#include <atomic>
+#endif
 
 #ifndef ROOT_Rtypes
 #include "Rtypes.h"
@@ -154,7 +157,11 @@ namespace TMVA {
    private:
 
       Types();
+#if __cplusplus > 199711L
+      static std::atomic<Types*> fgTypesPtr;
+#else
       static Types* fgTypesPtr;
+#endif
 
    private:
 

--- a/tmva/src/BDTEventWrapper.cxx
+++ b/tmva/src/BDTEventWrapper.cxx
@@ -26,7 +26,11 @@
 
 using namespace TMVA;
 
+#if __cplusplus > 199711L
+thread_local Int_t BDTEventWrapper::fVarIndex = 0;
+#else
 Int_t BDTEventWrapper::fVarIndex = 0;
+#endif
 
 BDTEventWrapper::BDTEventWrapper(const Event* e) : fEvent(e) {
    // constuctor

--- a/tmva/src/BinaryTree.cxx
+++ b/tmva/src/BinaryTree.cxx
@@ -46,8 +46,6 @@
 
 ClassImp(TMVA::BinaryTree)
 
-TMVA::MsgLogger* TMVA::BinaryTree::fgLogger = 0;
-
 //_______________________________________________________________________
 TMVA::BinaryTree::BinaryTree( void )
    : fRoot  ( NULL ),
@@ -55,7 +53,6 @@ TMVA::BinaryTree::BinaryTree( void )
      fDepth ( 0 )
 {
    // constructor for a yet "empty" tree. Needs to be filled afterwards
-   if (!fgLogger) fgLogger =  new MsgLogger("BinaryTree");
 }
 
 //_______________________________________________________________________
@@ -220,4 +217,14 @@ void TMVA::BinaryTree::SetTotalTreeDepth( Node *n)
    if (n->GetDepth() > this->GetTotalTreeDepth()) this->SetTotalTreeDepth(n->GetDepth());
 
    return;
+}
+
+//_______________________________________________________________________
+TMVA::MsgLogger& TMVA::BinaryTree::Log() const {
+#if __cplusplus > 199711L
+  static thread_local MsgLogger logger("BinaryTree");
+#else
+  static MsgLogger logger("BinaryTree");
+#endif
+  return logger;
 }

--- a/tmva/src/DataSetManager.cxx
+++ b/tmva/src/DataSetManager.cxx
@@ -52,7 +52,8 @@ using std::endl;
 
 //_______________________________________________________________________
 TMVA::DataSetManager::DataSetManager( DataInputHandler& dataInput )
-   : fDataInput(dataInput),
+   : fDatasetFactory(0),
+     fDataInput(dataInput),
      fDataSetInfoCollection(),
      fLogger( new MsgLogger("DataSetManager", kINFO) )
 {
@@ -65,7 +66,7 @@ TMVA::DataSetManager::~DataSetManager()
    // destructor
 //   fDataSetInfoCollection.SetOwner(); // DSMTEST --> created a segfault because the DataSetInfo-objects got deleted twice
 
-   TMVA::DataSetFactory::destroyInstance();
+  DataSetFactory::destroyNewInstance(fDatasetFactory);
    
    delete fLogger;
 }
@@ -78,7 +79,8 @@ TMVA::DataSet* TMVA::DataSetManager::CreateDataSet( const TString& dsiName )
    if (!dsi) Log() << kFATAL << "DataSetInfo object '" << dsiName << "' not found" << Endl;
 
    // factory to create dataset from datasetinfo and datainput
-   return TMVA::DataSetFactory::Instance().CreateDataSet( *dsi, fDataInput );
+   if(!fDatasetFactory) { fDatasetFactory = DataSetFactory::NewInstance(); }
+   return fDatasetFactory->CreateDataSet( *dsi, fDataInput );
 }
 
 //_______________________________________________________________________

--- a/tmva/src/DecisionTreeNode.cxx
+++ b/tmva/src/DecisionTreeNode.cxx
@@ -49,7 +49,6 @@ using std::string;
 
 ClassImp(TMVA::DecisionTreeNode)
 
-TMVA::MsgLogger* TMVA::DecisionTreeNode::fgLogger = 0;
 bool     TMVA::DecisionTreeNode::fgIsTraining = false;
 
 //_______________________________________________________________________
@@ -65,8 +64,6 @@ TMVA::DecisionTreeNode::DecisionTreeNode()
      fIsTerminalNode( kFALSE )
 {
    // constructor of an essentially "empty" node floating in space
-   if (!fgLogger) fgLogger = new TMVA::MsgLogger( "DecisionTreeNode" );
-
    if (DecisionTreeNode::fgIsTraining){
       fTrainInfo = new DTNodeTrainingInfo();
       //std::cout << "Node constructor with TrainingINFO"<<std::endl;
@@ -90,8 +87,6 @@ TMVA::DecisionTreeNode::DecisionTreeNode(TMVA::Node* p, char pos)
      fIsTerminalNode( kFALSE )
 {
    // constructor of a daughter node as a daughter of 'p'
-   if (!fgLogger) fgLogger = new TMVA::MsgLogger( "DecisionTreeNode" );
-
    if (DecisionTreeNode::fgIsTraining){
       fTrainInfo = new DTNodeTrainingInfo();
       //std::cout << "Node constructor with TrainingINFO"<<std::endl;
@@ -117,8 +112,6 @@ TMVA::DecisionTreeNode::DecisionTreeNode(const TMVA::DecisionTreeNode &n,
 {
    // copy constructor of a node. It will result in an explicit copy of
    // the node and recursively all it's daughters
-   if (!fgLogger) fgLogger = new TMVA::MsgLogger( "DecisionTreeNode" );
-
    this->SetParent( parent );
    if (n.GetLeft() == 0 ) this->SetLeft(NULL);
    else this->SetLeft( new DecisionTreeNode( *((DecisionTreeNode*)(n.GetLeft())),this));
@@ -186,8 +179,8 @@ void TMVA::DecisionTreeNode::SetPurity( void )
       fPurity = this->GetNSigEvents() / ( this->GetNSigEvents() + this->GetNBkgEvents());
    }
    else {
-      *fgLogger << kINFO << "Zero events in purity calcuation , return purity=0.5" << Endl;
-      this->Print(*fgLogger);
+      Log() << kINFO << "Zero events in purity calcuation , return purity=0.5" << Endl;
+      this->Print(Log());
       fPurity = 0.5;
    }
    return;
@@ -389,7 +382,7 @@ void TMVA::DecisionTreeNode::PrintRecPrune( std::ostream& os ) const {
 void TMVA::DecisionTreeNode::SetCC(Double_t cc)
 {
    if (fTrainInfo) fTrainInfo->fCC = cc;
-   else *fgLogger << kFATAL << "call to SetCC without trainingInfo" << Endl;
+   else Log() << kFATAL << "call to SetCC without trainingInfo" << Endl;
 }
 
 //_______________________________________________________________________
@@ -397,7 +390,7 @@ Float_t TMVA::DecisionTreeNode::GetSampleMin(UInt_t ivar) const {
    // return the minimum of variable ivar from the training sample
    // that pass/end up in this node
    if (fTrainInfo && ivar < fTrainInfo->fSampleMin.size()) return fTrainInfo->fSampleMin[ivar];
-   else *fgLogger << kFATAL << "You asked for Min of the event sample in node for variable "
+   else Log() << kFATAL << "You asked for Min of the event sample in node for variable "
                  << ivar << " that is out of range" << Endl;
    return -9999;
 }
@@ -407,7 +400,7 @@ Float_t TMVA::DecisionTreeNode::GetSampleMax(UInt_t ivar) const {
    // return the maximum of variable ivar from the training sample
    // that pass/end up in this node
    if (fTrainInfo && ivar < fTrainInfo->fSampleMin.size()) return fTrainInfo->fSampleMax[ivar];
-   else *fgLogger << kFATAL << "You asked for Max of the event sample in node for variable "
+   else Log() << kFATAL << "You asked for Max of the event sample in node for variable "
                  << ivar << " that is out of range" << Endl;
    return 9999;
 }
@@ -511,4 +504,13 @@ void TMVA::DecisionTreeNode::ReadContent( std::stringstream& /*s*/ )
    // reading attributes from tree node  (well, was used in BinarySearchTree,
    // and somehow I guess someone programmed it such that we need this in
    // this tree too, although we don't..)
+}
+//_______________________________________________________________________
+TMVA::MsgLogger& TMVA::DecisionTreeNode::Log() {
+#if __cplusplus > 199711L
+  static thread_local MsgLogger logger("DecisionTreeNode");    // static because there is a huge number of nodes...
+#else
+  static MsgLogger logger("DecisionTreeNode");    // static because there is a huge number of nodes...
+#endif
+  return logger;
 }

--- a/tmva/src/Interval.cxx
+++ b/tmva/src/Interval.cxx
@@ -75,16 +75,12 @@ End_Html */
 
 ClassImp(TMVA::Interval)
 
-TMVA::MsgLogger* TMVA::Interval::fgLogger = 0;
-
 //_______________________________________________________________________
 TMVA::Interval::Interval( Double_t min, Double_t max, Int_t nbins ) : 
    fMin(min),
    fMax(max),
    fNbins(nbins)
 {
-   if (!fgLogger) fgLogger = new MsgLogger("Interval");
-
    // defines minimum and maximum of an interval
    // when nbins > 0, interval describes a discrete distribution (equally distributed in the interval)
    // when nbins == 0, interval describes a continous interval
@@ -105,7 +101,6 @@ TMVA::Interval::Interval( const Interval& other ) :
    fMax  ( other.fMax ),
    fNbins( other.fNbins )
 {
-   if (!fgLogger) fgLogger = new MsgLogger("Interval");
 }
 
 //_______________________________________________________________________
@@ -167,4 +162,13 @@ void TMVA::Interval::Print(std::ostream &os) const
    for (Int_t i=0; i<GetNbins(); i++){
       os << "| " << GetElement(i)<<" |" ;
    }  
+}
+
+TMVA::MsgLogger& TMVA::Interval::Log() const {
+#if __cplusplus > 199711L
+  static thread_local MsgLogger logger("Interval");   // message logger
+#else
+  static MsgLogger logger("Interval");   // message logger
+#endif
+  return logger;
 }

--- a/tmva/src/LogInterval.cxx
+++ b/tmva/src/LogInterval.cxx
@@ -81,19 +81,16 @@ End_Html */
 
 ClassImp(TMVA::LogInterval)
 
-TMVA::MsgLogger* TMVA::LogInterval::fgLogger = 0;
 //_______________________________________________________________________
 TMVA::LogInterval::LogInterval( Double_t min, Double_t max, Int_t nbins ) :
 TMVA::Interval(min,max,nbins)
 {
-   if (!fgLogger) fgLogger = new MsgLogger("LogInterval");
    if (min<=0) Log() << kFATAL << "logarithmic intervals have to have Min>0 !!" << Endl;
 }
 
 TMVA::LogInterval::LogInterval( const LogInterval& other ) :
    TMVA::Interval(other)
 {
-   if (!fgLogger) fgLogger = new MsgLogger("LogInterval");
 }
 
 //_______________________________________________________________________
@@ -150,3 +147,11 @@ Double_t TMVA::LogInterval::GetMean()  const
    return (fMax + fMin)/2; 
 }
 
+TMVA::MsgLogger& TMVA::LogInterval::Log() const {
+#if __cplusplus > 199711L
+  static thread_local MsgLogger logger("LogInterval");   // message logger
+#else
+  static MsgLogger logger("LogInterval");   // message logger
+#endif
+  return logger;
+}

--- a/tmva/src/MethodANNBase.cxx
+++ b/tmva/src/MethodANNBase.cxx
@@ -40,6 +40,9 @@
 #include <vector>
 #include <cstdlib>
 #include <stdexcept>
+#if __cplusplus > 199711L
+#include <atomic>
+#endif
 
 #include "TString.h"
 #include "TTree.h"
@@ -980,13 +983,17 @@ void TMVA::MethodANNBase::WriteMonitoringHistosToFile() const
    CreateWeightMonitoringHists( "weights_hist" );
 
    // now save all the epoch-wise monitoring information
+#if __cplusplus > 199711L
+   static std::atomic<int> epochMonitoringDirectoryNumber{0};
+#else
    static int epochMonitoringDirectoryNumber = 0;
+#endif
+   int epochVal = epochMonitoringDirectoryNumber++;
    TDirectory* epochdir = NULL;
-   if( epochMonitoringDirectoryNumber == 0 )
+   if( epochVal == 0 )
       epochdir = BaseDir()->mkdir( "EpochMonitoring" );
    else
-      epochdir = BaseDir()->mkdir( Form("EpochMonitoring_%4d",epochMonitoringDirectoryNumber) );
-   ++epochMonitoringDirectoryNumber;
+      epochdir = BaseDir()->mkdir( Form("EpochMonitoring_%4d",epochVal) );
 
    epochdir->cd();
    for (std::vector<TH1*>::const_iterator it = fEpochMonHistS.begin(); it != fEpochMonHistS.end(); it++) {

--- a/tmva/src/MethodBase.cxx
+++ b/tmva/src/MethodBase.cxx
@@ -2171,7 +2171,11 @@ Double_t TMVA::MethodBase::GetEfficiency( const TString& theString, Types::ETree
    Double_t xmin = effhist->GetXaxis()->GetXmin();
    Double_t xmax = effhist->GetXaxis()->GetXmax();
 
+#if __cplusplus > 199711L
+   static thread_local Double_t nevtS;
+#else
    static Double_t nevtS;
+#endif
 
    // first round ? --> create histograms
    if (results->DoesExist("MVA_EFF_S")==0) {
@@ -3085,7 +3089,11 @@ void TMVA::MethodBase::PrintHelpMessage() const
 
 // ----------------------- r o o t   f i n d i n g ----------------------------
 
+#if __cplusplus > 199711L
+thread_local TMVA::MethodBase* TMVA::MethodBase::fgThisBase = 0;
+#else
 TMVA::MethodBase* TMVA::MethodBase::fgThisBase = 0;
+#endif
 
 //_______________________________________________________________________
 Double_t TMVA::MethodBase::IGetEffForRoot( Double_t theCut )

--- a/tmva/src/MethodCFMlpANN_Utils.cxx
+++ b/tmva/src/MethodCFMlpANN_Utils.cxx
@@ -72,12 +72,12 @@ using std::endl;
 
 ClassImp(TMVA::MethodCFMlpANN_Utils)
    
-Int_t       TMVA::MethodCFMlpANN_Utils::fg_100         = 100;
-Int_t       TMVA::MethodCFMlpANN_Utils::fg_0           = 0;
-Int_t       TMVA::MethodCFMlpANN_Utils::fg_max_nVar_   = max_nVar_;
-Int_t       TMVA::MethodCFMlpANN_Utils::fg_max_nNodes_ = max_nNodes_;
-Int_t       TMVA::MethodCFMlpANN_Utils::fg_999         = 999;
-const char* TMVA::MethodCFMlpANN_Utils::fg_MethodName  = "--- CFMlpANN                 ";
+Int_t             TMVA::MethodCFMlpANN_Utils::fg_100         = 100;
+Int_t             TMVA::MethodCFMlpANN_Utils::fg_0           = 0;
+const Int_t       TMVA::MethodCFMlpANN_Utils::fg_max_nVar_   = max_nVar_;
+const Int_t       TMVA::MethodCFMlpANN_Utils::fg_max_nNodes_ = max_nNodes_;
+Int_t             TMVA::MethodCFMlpANN_Utils::fg_999         = 999;
+const char* const TMVA::MethodCFMlpANN_Utils::fg_MethodName  = "--- CFMlpANN                 ";
 
 TMVA::MethodCFMlpANN_Utils::MethodCFMlpANN_Utils()
 {

--- a/tmva/src/MethodMLP.cxx
+++ b/tmva/src/MethodMLP.cxx
@@ -1583,8 +1583,13 @@ void TMVA::MethodMLP::IFCN( Int_t& npars, Double_t* grad, Double_t &f, Double_t*
    ((MethodMLP*)GetThisPtr())->FCN( npars, grad, f, fitPars, iflag );
 }
 
+#if __cplusplus > 199711L
+static thread_local Int_t  nc   = 0;
+static thread_local double minf = 1000000;
+#else
 static Int_t  nc   = 0;
 static double minf = 1000000;
+#endif
 
 void TMVA::MethodMLP::FCN( Int_t& npars, Double_t* grad, Double_t &f, Double_t* fitPars, Int_t iflag )
 {

--- a/tmva/src/MethodPDERS.cxx
+++ b/tmva/src/MethodPDERS.cxx
@@ -87,7 +87,11 @@ namespace TMVA {
    const Bool_t MethodPDERS_UseFindRoot = kFALSE;
 };
 
+#if __cplusplus > 199711L
+thread_local TMVA::MethodPDERS* TMVA::MethodPDERS::fgThisPDERS = NULL;
+#else
 TMVA::MethodPDERS* TMVA::MethodPDERS::fgThisPDERS = NULL;
+#endif
 
 REGISTER_METHOD(PDERS)
 
@@ -953,7 +957,11 @@ Double_t TMVA::MethodPDERS::KernelNormalization (Double_t pdf)
 
    // Caching jammed to disable function. 
    // It's not really useful afterall, badly implemented and untested :-)
+#if __cplusplus > 199711L
+   static thread_local Double_t ret = 1.0; 
+#else
    static Double_t ret = 1.0; 
+#endif
    
    if (ret != 0.0) return ret*pdf; 
 

--- a/tmva/src/MethodTMlpANN.cxx
+++ b/tmva/src/MethodTMlpANN.cxx
@@ -223,7 +223,11 @@ Double_t TMVA::MethodTMlpANN::GetMvaValue( Double_t* err, Double_t* errUpper )
 {
    // calculate the value of the neural net for the current event
    const Event* ev = GetEvent();
+#if __cplusplus > 199711L
+   static thread_local Double_t* d = new Double_t[Data()->GetNVariables()];
+#else
    static Double_t* d = new Double_t[Data()->GetNVariables()];
+#endif
    for (UInt_t ivar = 0; ivar<Data()->GetNVariables(); ivar++) {
       d[ivar] = (Double_t)ev->GetValue(ivar);
    }
@@ -412,8 +416,13 @@ void  TMVA::MethodTMlpANN::ReadWeightsFromXML( void* wghtnode )
 
    // Here we create a dummy tree necessary to create a minimal NN
    // to be used for testing, evaluation and application
+#if __cplusplus > 199711L
+   static thread_local Double_t* d = new Double_t[Data()->GetNVariables()] ;
+   static thread_local Int_t type;
+#else
    static Double_t* d = new Double_t[Data()->GetNVariables()] ;
    static Int_t type;
+#endif
 
    gROOT->cd();
    TTree * dummyTree = new TTree("dummy","Empty dummy tree", 1);
@@ -442,7 +451,7 @@ void  TMVA::MethodTMlpANN::ReadWeightsFromStream( std::istream& istr )
    Log() << kINFO << "Load TMLP weights into " << fMLP << Endl;
 
    Double_t* d = new Double_t[Data()->GetNVariables()] ; 
-   static Int_t type;
+   Int_t type;
    gROOT->cd();
    TTree * dummyTree = new TTree("dummy","Empty dummy tree", 1);
    for (UInt_t ivar = 0; ivar<Data()->GetNVariables(); ivar++) {

--- a/tmva/src/ModulekNN.cxx
+++ b/tmva/src/ModulekNN.cxx
@@ -153,7 +153,11 @@ std::ostream& TMVA::kNN::operator<<(std::ostream& os, const TMVA::kNN::Event& ev
 
 
 
+#if __cplusplus > 199711L
+thread_local TRandom3 TMVA::kNN::ModulekNN::fgRndm(1);
+#else
 TRandom3 TMVA::kNN::ModulekNN::fgRndm(1);
+#endif
 
 //-------------------------------------------------------------------------------------------
 TMVA::kNN::ModulekNN::ModulekNN()
@@ -378,7 +382,11 @@ Bool_t TMVA::kNN::ModulekNN::Find(const UInt_t nfind, const std::string &option)
       return kFALSE;
    }
    
+#if __cplusplus > 199711L
+   static thread_local std::map<Short_t, UInt_t>::const_iterator cit = fCount.end();
+#else
    static std::map<Short_t, UInt_t>::const_iterator cit = fCount.end();
+#endif
 
    if (cit == fCount.end()) {
       cit = fCount.begin();

--- a/tmva/src/Option.cxx
+++ b/tmva/src/Option.cxx
@@ -28,8 +28,6 @@
 
 #include "TMVA/Option.h"
 
-TMVA::MsgLogger* TMVA::OptionBase::fgLogger = 0;
-
 //______________________________________________________________________
 TMVA::OptionBase::OptionBase( const TString& name, const TString& desc ) 
    : TObject(), 
@@ -39,7 +37,6 @@ TMVA::OptionBase::OptionBase( const TString& name, const TString& desc )
      fIsSet       ( kFALSE )
 {
    // constructor
-   if (!fgLogger) fgLogger = new MsgLogger("Option",kDEBUG);
    fNameAllLower.ToLower();
 }
 
@@ -52,3 +49,12 @@ Bool_t TMVA::OptionBase::SetValue( const TString& vs, Int_t )
    return kTRUE;
 }
 
+TMVA::MsgLogger& TMVA::OptionBase::Log()
+{
+#if __cplusplus > 199711L
+  static thread_local MsgLogger logger("Option",kDEBUG);  // message logger
+#else
+  static MsgLogger logger("Option",kDEBUG);  // message logger
+#endif
+  return logger;
+}

--- a/tmva/src/PDF.cxx
+++ b/tmva/src/PDF.cxx
@@ -49,7 +49,11 @@
 const Int_t    TMVA::PDF::fgNbin_PdfHist      = 10000;
 const Bool_t   TMVA::PDF::fgManualIntegration = kTRUE;
 const Double_t TMVA::PDF::fgEpsilon           = 1.0e-12;
+#if __cplusplus > 199711L
+thread_local TMVA::PDF* TMVA::PDF::fgThisPDF  = 0;
+#else
 TMVA::PDF*     TMVA::PDF::fgThisPDF           = 0;
+#endif
 
 ClassImp(TMVA::PDF)
 

--- a/tmva/src/TNeuron.cxx
+++ b/tmva/src/TNeuron.cxx
@@ -51,13 +51,10 @@ using std::vector;
 
 ClassImp(TMVA::TNeuron)
 
-TMVA::MsgLogger* TMVA::TNeuron::fgLogger = 0;
-
 //______________________________________________________________________________
 TMVA::TNeuron::TNeuron()
 {
    // standard constructor
-   if (!fgLogger) fgLogger = new MsgLogger("TNeuron",kDEBUG);
    InitNeuron();
 }
 
@@ -333,4 +330,15 @@ void TMVA::TNeuron::PrintMessage( EMsgType type, TString message)
 {
    // print message, for debugging
    Log() << type << message << Endl;
+}
+
+//______________________________________________________________________________
+TMVA::MsgLogger& TMVA::TNeuron::Log() const 
+{
+  #if __cplusplus > 199711L
+  static thread_local MsgLogger logger("TNeuron",kDEBUG);    //! message logger, static to save resources
+#else
+  static MsgLogger logger("TNeuron",kDEBUG);                 //! message logger, static to save resources
+#endif
+  return logger;
 }

--- a/tmva/src/TSynapse.cxx
+++ b/tmva/src/TSynapse.cxx
@@ -40,8 +40,6 @@ static const Int_t fgUNINITIALIZED = -1;
 
 ClassImp(TMVA::TSynapse);
 
-TMVA::MsgLogger* TMVA::TSynapse::fgLogger = 0;
-
 //______________________________________________________________________________
 TMVA::TSynapse::TSynapse()
   : fWeight( 0 ),
@@ -54,7 +52,6 @@ TMVA::TSynapse::TSynapse()
 {
    // constructor
    fWeight     = fgUNINITIALIZED;
-   if (!fgLogger) fgLogger = new MsgLogger("TSynapse");
 }
 
 
@@ -107,4 +104,15 @@ void TMVA::TSynapse::CalculateDelta()
    // calculate/adjust the error field for this synapse
    fDelta += fPostNeuron->GetDelta() * fPreNeuron->GetActivationValue();
    fCount++;
+}
+
+//______________________________________________________________________________
+TMVA::MsgLogger& TMVA::TSynapse::Log() const 
+{
+#if __cplusplus > 199711L
+  static thread_local MsgLogger logger("TSynapse");  //! message logger, static to save resources
+#else
+  static MsgLogger logger("TSynapse");               //! message logger, static to save resources
+#endif
+  return logger;
 }

--- a/tmva/src/Types.cxx
+++ b/tmva/src/Types.cxx
@@ -27,11 +27,19 @@
 
 #include <map>
 #include <iostream>
+#if __cplusplus > 199711L
+#include <mutex>
+#endif
 
 #include "TMVA/Types.h"
 #include "TMVA/MsgLogger.h"
 
+#if __cplusplus > 199711L
+std::atomic<TMVA::Types*> TMVA::Types::fgTypesPtr{0};
+static std::mutex gTypesMutex;
+#else
 TMVA::Types* TMVA::Types::fgTypesPtr = 0;
+#endif
 
 //_______________________________________________________________________
 TMVA::Types::Types()
@@ -50,7 +58,19 @@ TMVA::Types::~Types()
 TMVA::Types& TMVA::Types::Instance() 
 { 
    // the the single instance of "Types" if existin already, or create it  (Signleton) 
+#if __cplusplus > 199711L
+  if(!fgTypesPtr) {
+    Types* tmp = new Types();
+    Types* expected = 0;
+    if(!fgTypesPtr.compare_exchange_strong(expected,tmp)) {
+      //Another thread already did it
+      delete tmp;
+    }
+  }
+  return *fgTypesPtr;
+#else
    return fgTypesPtr ? *fgTypesPtr : *(fgTypesPtr = new Types()); 
+#endif
 }
 //_______________________________________________________________________
 void   TMVA::Types::DestroyInstance() 
@@ -63,6 +83,9 @@ void   TMVA::Types::DestroyInstance()
 //_______________________________________________________________________
 Bool_t TMVA::Types::AddTypeMapping( Types::EMVA method, const TString& methodname ) 
 {
+#if __cplusplus > 199711L
+   std::lock_guard<std::mutex> guard(gTypesMutex);
+#endif
    std::map<TString, EMVA>::const_iterator it = fStr2type.find( methodname );
    if (it != fStr2type.end()) {
       Log() << kFATAL 
@@ -78,6 +101,9 @@ Bool_t TMVA::Types::AddTypeMapping( Types::EMVA method, const TString& methodnam
 //_______________________________________________________________________
 TMVA::Types::EMVA TMVA::Types::GetMethodType( const TString& method ) const 
 { 
+#if __cplusplus > 199711L
+   std::lock_guard<std::mutex> guard(gTypesMutex);
+#endif
    // returns the method type (enum) for a given method (string)
    std::map<TString, EMVA>::const_iterator it = fStr2type.find( method );
    if (it == fStr2type.end()) {
@@ -90,6 +116,9 @@ TMVA::Types::EMVA TMVA::Types::GetMethodType( const TString& method ) const
 //_______________________________________________________________________
 TString TMVA::Types::GetMethodName( TMVA::Types::EMVA method ) const 
 {
+#if __cplusplus > 199711L
+   std::lock_guard<std::mutex> guard(gTypesMutex);
+#endif
    std::map<TString, EMVA>::const_iterator it = fStr2type.begin();
    for (; it!=fStr2type.end(); it++) if (it->second == method) return it->first;
    Log() << kFATAL << "Unknown method index in map: " << method << Endl;


### PR DESCRIPTION
It is now possible to create independent TMVA::Readers and use
them simultaneously on different threads.
Training of MVAs is still only safe single-threaded. In addition,
it is not safe to use multiple instances of MethodCFMlpANN either
single or multi-threaded because of a global 'this' pointer.
