### PR TITLE
Adapt to Chris changes for multithreading.

### DIFF
--- a/tmva/src/DecisionTreeNode.cxx
+++ b/tmva/src/DecisionTreeNode.cxx
@@ -394,7 +394,7 @@ Float_t TMVA::DecisionTreeNode::GetSampleMin(UInt_t ivar) const {
    // return the minimum of variable ivar from the training sample
    // that pass/end up in this node
    if (fTrainInfo && ivar < fTrainInfo->fSampleMin.size()) return fTrainInfo->fSampleMin[ivar];
-   else *fgLogger << kFATAL << "You asked for Min of the event sample in node for variable "
+   else Log() << kFATAL << "You asked for Min of the event sample in node for variable "
                   << ivar << " that is out of range" << Endl;
    return -9999;
 }
@@ -404,7 +404,7 @@ Float_t TMVA::DecisionTreeNode::GetSampleMax(UInt_t ivar) const {
    // return the maximum of variable ivar from the training sample
    // that pass/end up in this node
    if (fTrainInfo && ivar < fTrainInfo->fSampleMin.size()) return fTrainInfo->fSampleMax[ivar];
-   else *fgLogger << kFATAL << "You asked for Max of the event sample in node for variable "
+   else Log() << kFATAL << "You asked for Max of the event sample in node for variable "
                   << ivar << " that is out of range" << Endl;
    return 9999;
 }


### PR DESCRIPTION
Chris removed the naked static pointer to fgLogger in
bf35e4fd98458baa5f3a8f3507f73bae4524739c however there are a few places
where it was used. This should address all the remaining issues.
