### PR TITLE
Another fix to make TFormula thread-safe

### DIFF
--- a/cint/cint/src/Method.cxx
+++ b/cint/cint/src/Method.cxx
@@ -19,6 +19,12 @@
 
 extern "C" int G__xrefflag;
 
+#if __cplusplus >= 201103L
+#define THREAD_LOCAL thread_local
+#else
+#define THREAD_LOCAL
+#endif
+
 /*********************************************************************
 * class G__MethodInfo
 *
@@ -163,7 +169,7 @@ struct G__ifunc_table* Cint::G__MethodInfo::ifunc()
 ///////////////////////////////////////////////////////////////////////////
 const char* Cint::G__MethodInfo::Title() 
 {
-  static char buf[G__INFO_TITLELEN];
+  THREAD_LOCAL static char buf[G__INFO_TITLELEN];
   buf[0]='\0';
   if(IsValid()) {
     struct G__ifunc_table_internal *ifunc2;
@@ -594,7 +600,7 @@ int Cint::G__MethodInfo::IsBusy()
 ///////////////////////////////////////////////////////////////////////////
 char* Cint::G__MethodInfo::GetPrototype()
 {
-  static G__FastAllocString *buf_ptr = new G__FastAllocString(G__LONGLINE);
+  THREAD_LOCAL static G__FastAllocString *buf_ptr = new G__FastAllocString(G__LONGLINE);
   G__FastAllocString &buf(*buf_ptr);  // valid until the next call of GetPrototype, just like any static
 
   if (!IsValid()) return 0;

--- a/cint/cint/src/Type.cxx
+++ b/cint/cint/src/Type.cxx
@@ -18,6 +18,11 @@
 #include "common.h"
 #include "FastAllocString.h"
 
+#if __cplusplus >= 201103L
+#define THREAD_LOCAL thread_local
+#else
+#define THREAD_LOCAL
+#endif
 /*********************************************************************
 * class G__TypeInfo
 * 
@@ -117,7 +122,7 @@ int Cint::G__TypeInfo::operator!=(const G__TypeInfo& a)
 ///////////////////////////////////////////////////////////////////////////
 const char* Cint::G__TypeInfo::TrueName() 
 {
-   static G__FastAllocString *buf_ptr = new G__FastAllocString(G__ONELINE);
+   THREAD_LOCAL static G__FastAllocString *buf_ptr = new G__FastAllocString(G__ONELINE);
    G__FastAllocString &buf(*buf_ptr);
 
    buf = G__type2string((int)type,(int)tagnum,-1,(int)reftype,(int)isconst);
@@ -126,7 +131,7 @@ const char* Cint::G__TypeInfo::TrueName()
 ///////////////////////////////////////////////////////////////////////////
 const char* Cint::G__TypeInfo::Name() 
 {
-   static G__FastAllocString *buf_ptr = new G__FastAllocString(G__ONELINE);
+   THREAD_LOCAL static G__FastAllocString *buf_ptr = new G__FastAllocString(G__ONELINE);
    G__FastAllocString &buf(*buf_ptr);
 
    buf = G__type2string((int)type,(int)tagnum,(int)typenum,(int)reftype

--- a/core/meta/src/TDataType.cxx
+++ b/core/meta/src/TDataType.cxx
@@ -21,6 +21,7 @@
 #include "TDataType.h"
 #include "TInterpreter.h"
 #include "TCollection.h"
+#include "TVirtualMutex.h"
 #ifdef R__SOLARIS
 #include <typeinfo>
 #endif
@@ -38,6 +39,7 @@ TDataType::TDataType(TypedefInfo_t *info) : TDictionary()
    fInfo = info;
 
    if (fInfo) {
+      R__LOCKGUARD2(gCINTMutex);
       SetName(gCint->TypedefInfo_Name(fInfo));
       SetTitle(gCint->TypedefInfo_Title(fInfo));
       SetType(gCint->TypedefInfo_TrueName(fInfo));
@@ -350,6 +352,7 @@ void TDataType::CheckInfo()
 
    // This intentionally cast the constness away so that
    // we can call CheckInfo from const data members.
+   R__LOCKGUARD2(gCINTMutex);
 
    if (!gCint->TypedefInfo_IsValid(fInfo) ||
        strcmp(gCint->TypedefInfo_Name(fInfo),fName.Data())!=0) {

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -390,6 +390,7 @@ TGenCollectionProxy::Value::Value(const std::string& inside_type, Bool_t silent)
          fDtor   = fType->GetDestructor();
          fDelete = fType->GetDelete();
       } else {
+         R__LOCKGUARD2(gCINTMutex);
 #if defined(NOT_YET)
          // Because the TStreamerInfo of the contained classes
          // is stored only when tbere at least one element in


### PR DESCRIPTION
There were additional crashes in the _THREADED IBs coming from TFormula. I traced the problem to TMethodCall::ReturnType returning the wrong values. This pull makes thread safe all the accesses other ROOT code does to the data structures being accessed by TMethodCall::ReturnType.
