### PR TITLE
Make TClass::fIsAMethod setting thread safe

### DIFF
--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -121,7 +121,11 @@ private:
 
    TVirtualIsAProxy  *fIsA;             //!pointer to the class's IsA proxy.
    IsAGlobalFunc_t    fGlobalIsA;       //pointer to a global IsA function.
+#if __cplusplus > 199711L
+   mutable std::atomic<TMethodCall*> fIsAMethod;       //!saved info to call a IsA member function
+#else
    mutable TMethodCall *fIsAMethod;       //!saved info to call a IsA member function
+#endif
 
    ROOT::MergeFunc_t   fMerge;          //pointer to a function implementing Merging objects of this class.
    ROOT::ResetAfterMergeFunc_t fResetAfterMerge; //pointer to a function implementing Merging objects of this class.

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1157,7 +1157,7 @@ TClass::TClass(const TClass& cl) :
   fSharedLibs(cl.fSharedLibs),
   fIsA(cl.fIsA),
   fGlobalIsA(cl.fGlobalIsA),
-  fIsAMethod(cl.fIsAMethod),
+  fIsAMethod(0),
   fMerge(cl.fMerge),
   fResetAfterMerge(cl.fResetAfterMerge),
   fNew(cl.fNew),
@@ -1285,7 +1285,11 @@ TClass::~TClass()
 
    delete fStreamer;
    delete fCollectionProxy;
+#if __cplusplus > 199711L
+   delete fIsAMethod.load();
+#else
    delete fIsAMethod;
+#endif
    delete fSchemaRules;
    if (fConversionStreamerInfo) {
       std::map<std::string, TObjArray*>::iterator it;
@@ -2241,18 +2245,28 @@ TClass *TClass::GetActualClass(const void *object) const
       //will not work if the class derives from TObject but not as primary
       //inheritance.
       if (fIsAMethod==0) {
-         fIsAMethod = new TMethodCall((TClass*)this, "IsA", "");
+         TMethodCall* temp = new TMethodCall((TClass*)this, "IsA", "");
 
-         if (!fIsAMethod->GetMethod()) {
-            delete fIsAMethod;
-            fIsAMethod = 0;
+         if (!temp->GetMethod()) {
+            delete temp;
             Error("IsA","Can not find any IsA function for %s!",GetName());
             return (TClass*)this;
          }
+#if __cplusplus > 199711L
+	 //Force cache to be updated here so do not have to worry about concurrency
+	 temp->ReturnType();
 
+	 TMethodCall* expected = nullptr;
+	 if( not fIsAMethod.compare_exchange_strong(expected,temp) ) {
+	   //another thread beat us to it
+	   delete temp;
+	 }
+#else
+	 fIsAMethod = temp;
+#endif
       }
       char * char_result = 0;
-      fIsAMethod->Execute((void*)object, &char_result);
+      (*fIsAMethod).Execute((void*)object, &char_result);
       return (TClass*)char_result;
    }
 }


### PR DESCRIPTION
Caching and initialization of TClass::fIsAMethod have been changed
to make them thread safe and for calls to the TMethodCall can happen
concurrently.
