### PR TITLE
Additional thread safety fixes v5_34_21

### DIFF
--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -244,7 +244,10 @@ TObject *TDirectory::CloneObject(const TObject *obj, Bool_t autoadd /* = kTRUE *
 
    // if no default ctor return immediately (error issued by New())
    char *pobj = (char*)obj->IsA()->New();
-   if (!pobj) return 0;
+   if (!pobj) {
+     Fatal("CloneObject","Failed to create new object");
+     return 0;
+   }
    
    Int_t baseOffset = obj->IsA()->GetBaseClassOffset(TObject::Class());
    if (baseOffset==-1) {
@@ -260,7 +263,10 @@ TObject *TDirectory::CloneObject(const TObject *obj, Bool_t autoadd /* = kTRUE *
    //We are forced to go via the I/O package (ie TBufferFile).
    //Invoking TBufferFile via CINT will automatically load the I/O library
    TBuffer *buffer = (TBuffer*)gROOT->ProcessLine("new TBufferFile(TBuffer::kWrite,10000);");
-   if (!buffer) return 0;
+   if (!buffer) {
+     Fatal("CloneObject","Not able to create a TBuffer!");
+     return 0;
+   }
    buffer->MapObject(obj);  //register obj in map to handle self reference
    const_cast<TObject*>(obj)->Streamer(*buffer);
 

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -205,8 +205,12 @@ TObject *TObject::Clone(const char *) const
    // This usually means that the object will be appended to the current
    // ROOT directory.
 
-   if (gDirectory) return gDirectory->CloneObject(this);
-   else            return 0;
+   if (gDirectory) {
+     return gDirectory->CloneObject(this);
+   } else {
+     Fatal("Clone","No gDirectory set");
+     return 0;
+   }
 }
 
 //______________________________________________________________________________

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1030,7 +1030,7 @@ TClass *TROOT::FindSTLClass(const char *name, Bool_t load, Bool_t silent) const
    // return a TClass object corresponding to 'name' assuming it is an STL container.
    // In particular we looking for possible alternative name (default template
    // parameter, typedefs template arguments, typedefed name).
-
+   R__LOCKGUARD(gCINTMutex);
    return R__FindSTLClass(name,load,silent,name);
 }
 
@@ -1498,7 +1498,10 @@ TClass *TROOT::LoadClass(const char *requestedname, Bool_t silent) const
 
    if (!dict) {
       // Try to remove the ROOT typedefs
-      resolved = TClassEdit::ResolveTypedef(classname,kTRUE);
+      {
+         R__LOCKGUARD(gCINTMutex);
+	 resolved = TClassEdit::ResolveTypedef(classname,kTRUE);
+      }
       if (resolved != classname) {
          dict = TClassTable::GetDict(resolved.Data());
       } else {

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -143,7 +143,11 @@ private:
    TString            fContextMenuTitle;//context menu title
    const type_info   *fTypeInfo;        //pointer to the C++ type information.
    ShowMembersFunc_t  fShowMembers;     //pointer to the class's ShowMembers function
+#if __cplusplus >= 201103L
+   mutable std::atomic<void*> fInterShowMembers;//Interpreter call setup for ShowMembers
+#else
    mutable void      *fInterShowMembers;//Interpreter call setup for ShowMembers
+#endif
    TClassStreamer    *fStreamer;        //pointer to streamer function
    TString            fSharedLibs;      //shared libraries containing class code
 
@@ -167,10 +171,11 @@ private:
    Int_t               fSizeof;         //Sizeof the class.
 
    mutable Int_t      fCanSplit;        //!Indicates whether this class can be split or not.
-   mutable Long_t     fProperty;        //!Property
 #if __cplusplus >= 201103L
+   mutable std::atomic<Long_t> fProperty;        //!Property
    mutable std::atomic<Bool_t> fVersionUsed;     //!Indicates whether GetClassVersion has been called
 #else
+   mutable Long_t     fProperty;        //!Property
    mutable Bool_t     fVersionUsed;     //!Indicates whether GetClassVersion has been called
 #endif
 

--- a/core/meta/src/TCint.cxx
+++ b/core/meta/src/TCint.cxx
@@ -2103,8 +2103,9 @@ void *TCint::FindSpecialObject(const char *item, G__ClassInfo *type,
    // This function tries to find the UO in the ROOT files, directories, etc.
    // This functions has been registered by the TCint ctor.
 
-   if (!*prevObj || *assocPtr != gDirectory) {
+   //must protect calls to fgSetOfSpecials and call to G__ClassInfo::Init
    R__LOCKGUARD(gCINTMutex);
+   if (!*prevObj || *assocPtr != gDirectory) {
       *prevObj = gROOT->FindSpecialObject(item, *assocPtr);
       if (!fgSetOfSpecials) fgSetOfSpecials = new std::set<TObject*>;
       if (*prevObj) ((std::set<TObject*>*)fgSetOfSpecials)->insert((TObject*)*prevObj);

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1192,7 +1192,7 @@ TClass::TClass(const TClass& cl) :
   fContextMenuTitle(cl.fContextMenuTitle),
   fTypeInfo(cl.fTypeInfo),
   fShowMembers(cl.fShowMembers),
-  fInterShowMembers(cl.fInterShowMembers),
+  fInterShowMembers(0),
   fStreamer(cl.fStreamer),
   fSharedLibs(cl.fSharedLibs),
   fIsA(cl.fIsA),
@@ -1209,7 +1209,7 @@ TClass::TClass(const TClass& cl) :
   fStreamerFunc(cl.fStreamerFunc),
   fSizeof(cl.fSizeof),
   fCanSplit(cl.fCanSplit),
-  fProperty(cl.fProperty),
+  fProperty(0),
   fVersionUsed(),
   fIsOffsetStreamerSet(cl.fIsOffsetStreamerSet),
   fOffsetStreamer(cl.fOffsetStreamer),
@@ -1317,7 +1317,11 @@ TClass::~TClass()
 
    fIsOffsetStreamerSet=kFALSE;
 
+#if __cplusplus >= 201103L
+   if (fInterShowMembers) gCint->CallFunc_Delete(fInterShowMembers.load());
+#else
    if (fInterShowMembers) gCint->CallFunc_Delete(fInterShowMembers);
+#endif
 
    if ( fIsA ) delete fIsA;
 
@@ -1890,20 +1894,24 @@ Bool_t TClass::CallShowMembers(void* obj, TMemberInspector &insp,
          //
 
          if (!fInterShowMembers) {
-            CallFunc_t* ism = gCint->CallFunc_Factory();
-            Long_t offset = 0;
             
             R__LOCKGUARD2(gCINTMutex);
-            gCint->CallFunc_SetFuncProto(ism,fClassInfo,"ShowMembers", "TMemberInspector&", &offset);
-            if (fIsOffsetStreamerSet && offset != fOffsetStreamer) {
-               Error("CallShowMembers", "Logic Error: offset for Streamer() and ShowMembers() differ!");
-               fInterShowMembers = 0;
-               return kFALSE;
-            }
+	    if(!fInterShowMembers) {
+	       CallFunc_t* ism = gCint->CallFunc_Factory();
+	       Long_t offset = 0;
 
-            fInterShowMembers = ism;
+	       gCint->CallFunc_SetFuncProto(ism,fClassInfo,"ShowMembers", "TMemberInspector&", &offset);
+	       if (fIsOffsetStreamerSet && offset != fOffsetStreamer) {
+		  Error("CallShowMembers", "Logic Error: offset for Streamer() and ShowMembers() differ!");
+		  fInterShowMembers = 0;
+		  return kFALSE;
+	       }
+	      
+	       fInterShowMembers = ism;
+	    }
          }
-         if (!gCint->CallFunc_IsValid(fInterShowMembers)) {
+	 void* interShowMembers = fInterShowMembers;
+         if (!gCint->CallFunc_IsValid(interShowMembers)) {
             if (strcmp(GetName(), "string") == 0) {
                // For std::string we know that we do not have a ShowMembers
                // function and that it's okay.
@@ -1914,10 +1922,10 @@ Bool_t TClass::CallShowMembers(void* obj, TMemberInspector &insp,
             return kFALSE;
          } else {
             R__LOCKGUARD2(gCINTMutex);
-            gCint->CallFunc_ResetArg(fInterShowMembers);
-            gCint->CallFunc_SetArg(fInterShowMembers,(Long_t) &insp);
+            gCint->CallFunc_ResetArg(interShowMembers);
+            gCint->CallFunc_SetArg(interShowMembers,(Long_t) &insp);
             void* address = (void*) (((Long_t) obj) + fOffsetStreamer);
-            gCint->CallFunc_Exec((CallFunc_t*)fInterShowMembers,address);
+            gCint->CallFunc_Exec((CallFunc_t*)interShowMembers,address);
             return kTRUE;
          }
       } else if (TVirtualStreamerInfo* sinfo = GetStreamerInfo()) {
@@ -4094,6 +4102,8 @@ void *TClass::New(ENewType defConstructor) const
       // Register the object for special handling in the destructor.
       if (p) {
          RegisterAddressInRepository("New",p,this);
+      } else {
+	Error("New", "Failed to construct class '%s' using streamer info", GetName());
       }
    } else {
       Error("New", "This cannot happen!");
@@ -4898,8 +4908,6 @@ Long_t TClass::Property() const
 
    if (fClassInfo) {
 
-      kl->fProperty = gCint->ClassInfo_Property(fClassInfo);
-
       if (!gCint->ClassInfo_HasMethod(fClassInfo,"Streamer") ||
           !gCint->ClassInfo_IsValidMethod(fClassInfo,"Streamer","TBuffer&",&dummy) ) {
 
@@ -4927,6 +4935,9 @@ Long_t TClass::Property() const
          kl->fStreamerType  = kExternal;
          kl->fStreamerImpl  = &TClass::StreamerExternal;
       }
+      //must set this last since other threads may read fProperty
+      // and think all test bits have been properly set
+      kl->fProperty = gCint->ClassInfo_Property(fClassInfo);
 
    } else {
 

--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -202,7 +202,11 @@ TStreamerElement::TStreamerElement(const char *name, const char *title, Int_t of
    fNewType     = fType;
    fArrayDim    = 0;
    fArrayLength = 0;
-   fTypeName    = TClassEdit::ResolveTypedef(typeName);
+   {
+      //must protect call into the interpreter
+      R__LOCKGUARD2(gCINTMutex);
+      fTypeName    = TClassEdit::ResolveTypedef(typeName);
+   }
    fStreamer    = 0;
    fClassObject = (TClass*)(-1);
    fNewClass    = 0;

--- a/hist/hist/src/TProfileHelper.h
+++ b/hist/hist/src/TProfileHelper.h
@@ -440,6 +440,9 @@ T* TProfileHelper::RebinAxis(T* p, Double_t x, TAxis *axis)
 
    //save a copy of this histogram
    T *hold = (T*)p->Clone();
+   if(nullptr ==hold) {
+     Fatal("RebinAxis","Call to Clone returned a null");
+   }
    hold->SetDirectory(0);
    //set new axis limits
    axis->SetLimits(xmin,xmax);


### PR DESCRIPTION
This should fix the periodic crashes seen in the CMSSW_7_3_THREADED_X IBs. Additionally, we should get exceptions if a similar problem occurs later on.
This is the same fix as #33 but for ROOT 5-34-21.
