### PR TITLE
Synchronize construction of TApplication

### DIFF
--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -31,6 +31,9 @@
 #ifndef ROOT_TList
 #include "TList.h"
 #endif
+#if __cplusplus >= 201103L
+#include <atomic>
+#endif
 
 class TClass;
 class TCanvas;
@@ -84,7 +87,11 @@ protected:
    TString         fGitBranch;            //Git branch
    TString         fGitDate;              //Date and time when make was run
    Int_t           fTimer;                //Timer flag
+#if __cplusplus >= 201103L
+   std::atomic<TApplication*> fApplication;         //Pointer to current application
+#else
    TApplication    *fApplication;         //Pointer to current application
+#endif
    TInterpreter    *fInterpreter;         //Command interpreter
    Bool_t          fBatch;                //True if session without graphics
    Bool_t          fEditHistograms;       //True if histograms can be edited with the mouse

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -44,6 +44,7 @@
 #include "TClassTable.h"
 #include "TBrowser.h"
 #include "TUrl.h"
+#include "TVirtualMutex.h"
 
 #include <stdlib.h>
 
@@ -115,7 +116,7 @@ TApplication::TApplication(const char *appClassName, Int_t *argc, char **argv,
    // except if you want to by-pass the argv processing by GetOptions()
    // in which case you should specify numOptions<0. All options will
    // still be available via the Argv() method for later use.
-
+   R__LOCKGUARD2(gCINTMutex);
    if (gApplication && gApplication->TestBit(kDefaultApplication)) {
       // allow default TApplication to be replaced by a "real" TApplication
       delete gApplication;
@@ -140,7 +141,6 @@ TApplication::TApplication(const char *appClassName, Int_t *argc, char **argv,
       atexit(CallEndOfProcessCleanups);
    }
    gApplication = this;
-   gROOT->SetApplication(this);
    gROOT->SetName(appClassName);
 
    // Create the list of applications the first time
@@ -200,6 +200,10 @@ TApplication::TApplication(const char *appClassName, Int_t *argc, char **argv,
          gROOT->ProcessLine(Form("new TMemStat(\"%s\",%d,%d);",ssystem,buffersize,maxcalls));
       }
    }
+
+   //Needs to be done last
+   gROOT->SetApplication(this);
+
 }
 
 //______________________________________________________________________________

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1316,9 +1316,9 @@ void TROOT::Idle(UInt_t idleTimeInSec, const char *command)
       TApplication::CreateApplication();
 
    if (idleTimeInSec <= 0)
-      fApplication->RemoveIdleTimer();
+      (*fApplication).RemoveIdleTimer();
    else
-      fApplication->SetIdleTimer(idleTimeInSec, command);
+      (*fApplication).SetIdleTimer(idleTimeInSec, command);
 }
 
 //______________________________________________________________________________
@@ -1738,7 +1738,7 @@ Long_t TROOT::ProcessLine(const char *line, Int_t *error)
    if (!fApplication)
       TApplication::CreateApplication();
 
-   return fApplication->ProcessLine(sline, kFALSE, error);
+   return (*fApplication).ProcessLine(sline, kFALSE, error);
 }
 
 //______________________________________________________________________________
@@ -1758,7 +1758,7 @@ Long_t TROOT::ProcessLineSync(const char *line, Int_t *error)
    if (!fApplication)
       TApplication::CreateApplication();
 
-   return fApplication->ProcessLine(sline, kTRUE, error);
+   return (*fApplication).ProcessLine(sline, kTRUE, error);
 }
 
 //______________________________________________________________________________


### PR DESCRIPTION
It was possible for multiple threads to attempt construction of a
TApplication or for one thread to think the TApplication was already
constructed while another thread was in the process of doing the
construction.
