### PR TITLE
Always delete the array when the array size goes down to zero.

### DIFF
--- a/io/io/src/TStreamerInfoReadBuffer.cxx
+++ b/io/io/src/TStreamerInfoReadBuffer.cxx
@@ -96,6 +96,10 @@ TStreamerElement *TStreamerInfo::GetCurrentElement()
          f[j] = new name[*l];                   \
          b.ReadFastArray(f[j],*l);              \
       }                                         \
+      else for(j=0;j<compinfo[i]->fLength;j++) {  \
+        delete [] f[j];                        \
+        f[j] = 0;                              \
+     }                                         \
    }
 
 #define ReadBasicPointer(name)                  \


### PR DESCRIPTION
This fixes a problem seen by CMS when using TH1::Copy on histograms read
from a TTree.

This amend commit d31f38f98c66af492c20c3bf060df13d64c465f0 (circa 2005)
