### PR TITLE
Improve thread-safe correctness by setting created value last.

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -140,7 +140,6 @@ TApplication::TApplication(const char *appClassName, Int_t *argc, char **argv,
       // If we are the first TApplication register the atexit)
       atexit(CallEndOfProcessCleanups);
    }
-   gApplication = this;
    gROOT->SetName(appClassName);
 
    // Create the list of applications the first time
@@ -202,6 +201,7 @@ TApplication::TApplication(const char *appClassName, Int_t *argc, char **argv,
    }
 
    //Needs to be done last
+   gApplication = this;
    gROOT->SetApplication(this);
 
 }
@@ -1235,18 +1235,23 @@ void TApplication::CreateApplication()
    // Static function used to create a default application environment.
 
    if (!gApplication) {
-      char *a = StrDup("RootApp");
-      char *b = StrDup("-b");
-      char *argv[2];
-      Int_t argc = 2;
-      argv[0] = a;
-      argv[1] = b;
-      new TApplication("RootApp", &argc, argv, 0, 0);
-      if (gDebug > 0)
-         Printf("<TApplication::CreateApplication>: "
-                "created default TApplication");
-      delete [] a; delete [] b;
-      gApplication->SetBit(kDefaultApplication);
+      R__LOCKGUARD2(gROOTMutex);
+
+      // gApplication is set at the end of 'new TApplication.
+      if (!gApplication) {
+         char *a = StrDup("RootApp");
+         char *b = StrDup("-b");
+         char *argv[2];
+         Int_t argc = 2;
+         argv[0] = a;
+         argv[1] = b;
+         new TApplication("RootApp", &argc, argv, 0, 0);
+         if (gDebug > 0)
+            Printf("<TApplication::CreateApplication>: "
+                   "created default TApplication");
+         delete [] a; delete [] b;
+         gApplication->SetBit(kDefaultApplication);
+      }
    }
 }
 

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1278,6 +1278,8 @@ TCollection *TROOT::GetListOfGlobalFunctions(Bool_t load)
    // a (tight) loop where no interpreter symbols will be created
    // you can set load=kFALSE (default).
 
+   R__LOCKGUARD2(gCINTMutex);
+
    if (!fGlobalFunctions) {
       fGlobalFunctions = new THashTable(100, 3);
       load = kTRUE;
@@ -1286,6 +1288,10 @@ TCollection *TROOT::GetListOfGlobalFunctions(Bool_t load)
    if (!fInterpreter)
       Fatal("GetListOfGlobalFunctions", "fInterpreter not initialized");
 
+   // A thread that calls with load==true and a thread that calls with load==false
+   // will conflict here (the load==true will be updating the list while the
+   // other is reading it).  To solve the problem, we could use a read-write lock
+   // inside the list itself.
    if (load)
       gInterpreter->UpdateListOfGlobalFunctions();
 
@@ -1302,15 +1308,26 @@ TCollection *TROOT::GetListOfTypes(Bool_t load)
    // a (tight) loop where no new types will be created
    // you can set load=kFALSE (default).
 
-   if (!fTypes) {
-      fTypes = new THashTable(100, 3);
-      load = kTRUE;
-      TDataType::AddBuiltins(fTypes);
-   }
-
    if (!fInterpreter)
       Fatal("GetListOfTypes", "fInterpreter not initialized");
 
+   R__LOCKGUARD2(gCINTMutex);
+
+   if (!fTypes) {
+
+      fTypes = new THashTable(100, 3);
+      TDataType::AddBuiltins(fTypes);
+
+      gInterpreter->UpdateListOfTypes();
+
+      return fTypes;
+   }
+
+
+   // A thread that calls with load==true and a thread that calls with load==false
+   // will conflict here (the load==true will be updating the list while the
+   // other is reading it).  To solve the problem, we could use a read-write lock
+   // inside the list itself.
    if (load) {
 ///      printf("calling Update ListOfTypes\n");
       gInterpreter->UpdateListOfTypes();

--- a/core/meta/src/TCint.cxx
+++ b/core/meta/src/TCint.cxx
@@ -1100,16 +1100,18 @@ void TCint::CreateListOfBaseClasses(TClass *cl)
 
    if (!cl->fBase) {
 
-      cl->fBase = new TList;
+      TList *newlist = new TList;
 
       G__BaseClassInfo t(*(G__ClassInfo *)cl->GetClassInfo()), *a;
       while (t.Next()) {
          // if name cannot be obtained no use to put in list
          if (t.IsValid() && t.Name()) {
             a = new G__BaseClassInfo(t);
-            cl->fBase->Add(new TBaseClass(a, cl));
+            newlist->Add(new TBaseClass(a, cl));
          }
       }
+      // Set at the end, so other thread do not find it 'half' filled.
+      cl->fBase = newlist;
    }
 }
 
@@ -1122,16 +1124,18 @@ void TCint::CreateListOfDataMembers(TClass *cl)
 
    if (!cl->fData) {
 
-      cl->fData = new TList;
+      TList *newlist = new TList;
 
       G__DataMemberInfo t(*(G__ClassInfo*)cl->GetClassInfo()), *a;
       while (t.Next()) {
          // if name cannot be obtained no use to put in list
          if (t.IsValid() && t.Name() && strcmp(t.Name(), "G__virtualinfo")) {
             a = new G__DataMemberInfo(t);
-            cl->fData->Add(new TDataMember(a, cl));
+            newlist->Add(new TDataMember(a, cl));
          }
       }
+      // Set at the end, so other thread do not find it 'half' filled.
+      cl->fData = newlist;
    }
 }
 
@@ -1144,7 +1148,7 @@ void TCint::CreateListOfMethods(TClass *cl)
 
    if (!cl->fMethod) {
 
-      cl->fMethod = new THashList;
+      TList *newlist = new THashList;
 
       G__MethodInfo *a;
       G__MethodInfo t(*(G__ClassInfo*)cl->GetClassInfo());
@@ -1152,9 +1156,11 @@ void TCint::CreateListOfMethods(TClass *cl)
          // if name cannot be obtained no use to put in list
          if (t.IsValid() && t.Name()) {
             a = new G__MethodInfo(t);
-            cl->fMethod->Add(new TMethod(a, cl));
+            newlist->Add(new TMethod(a, cl));
          }
       }
+      // Set at the end, so other thread do not find it 'half' filled.
+      cl->fMethod = newlist;
    }
 }
 
@@ -1185,16 +1191,19 @@ void TCint::CreateListOfMethodArgs(TFunction *m)
 
    if (!m->fMethodArgs) {
 
-      m->fMethodArgs = new TList;
+      TList *newlist = new TList;
 
       G__MethodArgInfo t(*(G__MethodInfo *)m->fInfo), *a;
       while (t.Next()) {
          // if type cannot be obtained no use to put in list
          if (t.IsValid() && t.Type()) {
             a = new G__MethodArgInfo(t);
-            m->fMethodArgs->Add(new TMethodArg(a, m));
+            newlist->Add(new TMethodArg(a, m));
          }
       }
+
+      // Set at the end, so other thread do not find it 'half' filled.
+      m->fMethodArgs = newlist;
    }
 }
 


### PR DESCRIPTION
This avoids a second thread from using the created object (TList for example) before it is completely set/filed.