### PR TITLE
Workaround overflows in alphanumeric histos

### DIFF
--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -299,7 +299,7 @@ Int_t TAxis::FindBin(const char *label)
    if (!fLabels) {
       if (!fParent) return -1;
       fLabels = new THashList(1,1);
-      SetCanExtend(kTRUE);
+      // SetCanExtend(kTRUE);
       SetAlphanumeric(kTRUE);
       if (fXmax <= fXmin) {
          //L.M. Dec 2010 in case of no min and max specified use 0 ->NBINS
@@ -320,7 +320,7 @@ Int_t TAxis::FindBin(const char *label)
       }
       else { 
          Info("FindBin","Label %s not in the list will be added to the histogram",label);
-         SetCanExtend(kTRUE);
+         // SetCanExtend(kTRUE);
          SetAlphanumeric(kTRUE);
       }
    }
@@ -772,7 +772,7 @@ void TAxis::SetBinLabel(Int_t bin, const char *label)
    // check for Alphanumeric case (labels for each bin)
    if (fLabels->GetSize() == fNbins) {
       SetAlphanumeric(kTRUE);
-      SetCanExtend(kTRUE);
+      // SetCanExtend(kTRUE);
    }
 }
 


### PR DESCRIPTION
Comment out SetCanExtend to avoid issue with overflows  in alphanumeric histos