### PR TITLE
Protect concurrent access to gROOT->GetListOfFiles()

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1063,6 +1063,7 @@ TObject *TROOT::FindObjectAnyFile(const char *name) const
 {
    // Scan the memory lists of all files for an object with name
 
+   R__LOCKGUARD(gROOTMutex);
    TDirectory *d;
    TIter next(GetListOfFiles());
    while ((d = (TDirectory*)next())) {
@@ -1196,6 +1197,7 @@ TFile *TROOT::GetFile(const char *name) const
 {
    // Return pointer to file with name.
 
+   R__LOCKGUARD(gROOTMutex);
    return (TFile*)GetListOfFiles()->FindObject(name);
 }
 

--- a/io/sql/src/TSQLFile.cxx
+++ b/io/sql/src/TSQLFile.cxx
@@ -706,6 +706,7 @@ void TSQLFile::Close(Option_t *option)
    }
    pidDeleted.Delete();
 
+   R__LOCKGUARD(gROOTMutex);
    gROOT->GetListOfFiles()->Remove(this);
 }
 
@@ -1049,7 +1050,10 @@ void TSQLFile::InitSqlDatabase(Bool_t create)
       }
    }
 
-   gROOT->GetListOfFiles()->Add(this);
+   {
+      R__LOCKGUARD(gROOTMutex);
+      gROOT->GetListOfFiles()->Add(this);
+   }
    cd();
 
    fNProcessIDs = 0;

--- a/io/xml/src/TXMLFile.cxx
+++ b/io/xml/src/TXMLFile.cxx
@@ -295,7 +295,10 @@ void TXMLFile::InitXmlFile(Bool_t create)
       ReadFromFile();
    }
 
-   gROOT->GetListOfFiles()->Add(this);
+   {
+      R__LOCKGUARD(gROOTMutex);
+      gROOT->GetListOfFiles()->Add(this);
+   }
    cd();
 
    fNProcessIDs = 0;
@@ -358,6 +361,7 @@ void TXMLFile::Close(Option_t *option)
    }
    pidDeleted.Delete();
 
+   R__LOCKGUARD(gROOTMutex);
    gROOT->GetListOfFiles()->Remove(this);
 }
 

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -1163,10 +1163,13 @@ Int_t TTreePlayer::MakeClass(const char *classname, const char *option)
          fprintf(fp,"      // of trees.\n");
          fprintf(fp,"      TChain * chain = new TChain(\"%s\",\"%s\");\n",
                  fTree->GetName(),fTree->GetTitle());
-         TIter next(((TChain*)fTree)->GetListOfFiles());
-         TChainElement *element;
-         while ((element = (TChainElement*)next())) {
-            fprintf(fp,"      chain->Add(\"%s/%s\");\n",element->GetTitle(),element->GetName());
+         {
+            R__LOCKGUARD(gROOTMutex);
+            TIter next(((TChain*)fTree)->GetListOfFiles());
+            TChainElement *element;
+            while ((element = (TChainElement*)next())) {
+               fprintf(fp,"      chain->Add(\"%s/%s\");\n",element->GetTitle(),element->GetName());
+            }
          }
          fprintf(fp,"      tree = chain;\n");
          fprintf(fp,"#endif // SINGLE_TREE\n\n");
@@ -1604,10 +1607,13 @@ Int_t TTreePlayer::MakeCode(const char *filename)
       fprintf(fp,"   // of trees.\n");
       fprintf(fp,"   TChain *%s = new TChain(\"%s\",\"%s\");\n",
                  fTree->GetName(),fTree->GetName(),fTree->GetTitle());
-      TIter next(((TChain*)fTree)->GetListOfFiles());
-      TChainElement *element;
-      while ((element = (TChainElement*)next())) {
-         fprintf(fp,"   %s->Add(\"%s/%s\");\n",fTree->GetName(),element->GetTitle(),element->GetName());
+      {
+         R__LOCKGUARD(gROOTMutex);
+         TIter next(((TChain*)fTree)->GetListOfFiles());
+         TChainElement *element;
+         while ((element = (TChainElement*)next())) {
+            fprintf(fp,"   %s->Add(\"%s/%s\");\n",fTree->GetName(),element->GetTitle(),element->GetName());
+         }
       }
       fprintf(fp,"#endif // SINGLE_TREE\n\n");
    }


### PR DESCRIPTION
Use the gROOTMutex to protect access to possible concurrent accesses
to gROOT->GetListOfFiles().