### PR TITLE
Add locks to calls involving TCling interpreter classes

### DIFF
--- a/core/meta/src/TCling.cxx
+++ b/core/meta/src/TCling.cxx
@@ -6114,6 +6114,7 @@ Double_t TCling::CallFunc_ExecDouble(CallFunc_t* func, void* address) const
 //______________________________________________________________________________
 CallFunc_t* TCling::CallFunc_Factory() const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    return (CallFunc_t*) new TClingCallFunc(fInterpreter,*fNormalizedCtxt);
 }
 
@@ -6140,6 +6141,7 @@ void TCling::CallFunc_IgnoreExtraArgs(CallFunc_t* func, bool ignore) const
 //______________________________________________________________________________
 void TCling::CallFunc_Init(CallFunc_t* func) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    TClingCallFunc* f = (TClingCallFunc*) func;
    f->Init();
 }
@@ -6357,6 +6359,7 @@ void TCling::ClassInfo_Destruct(ClassInfo_t* cinfo, void* arena) const
 //______________________________________________________________________________
 ClassInfo_t* TCling::ClassInfo_Factory(Bool_t all) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    return (ClassInfo_t*) new TClingClassInfo(fInterpreter, all);
 }
 
@@ -6369,6 +6372,7 @@ ClassInfo_t* TCling::ClassInfo_Factory(ClassInfo_t* cinfo) const
 //______________________________________________________________________________
 ClassInfo_t* TCling::ClassInfo_Factory(const char* name) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    return (ClassInfo_t*) new TClingClassInfo(fInterpreter, name);
 }
 
@@ -6396,6 +6400,7 @@ bool TCling::ClassInfo_HasMethod(ClassInfo_t* cinfo, const char* name) const
 //______________________________________________________________________________
 void TCling::ClassInfo_Init(ClassInfo_t* cinfo, const char* name) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    TClingClassInfo* TClinginfo = (TClingClassInfo*) cinfo;
    TClinginfo->Init(name);
 }
@@ -6403,6 +6408,7 @@ void TCling::ClassInfo_Init(ClassInfo_t* cinfo, const char* name) const
 //______________________________________________________________________________
 void TCling::ClassInfo_Init(ClassInfo_t* cinfo, int tagnum) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    TClingClassInfo* TClinginfo = (TClingClassInfo*) cinfo;
    TClinginfo->Init(tagnum);
 }
@@ -6557,6 +6563,7 @@ void TCling::BaseClassInfo_Delete(BaseClassInfo_t* bcinfo) const
 //______________________________________________________________________________
 BaseClassInfo_t* TCling::BaseClassInfo_Factory(ClassInfo_t* cinfo) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    TClingClassInfo* TClinginfo = (TClingClassInfo*) cinfo;
    return (BaseClassInfo_t*) new TClingBaseClassInfo(fInterpreter, TClinginfo);
 }
@@ -6565,6 +6572,7 @@ BaseClassInfo_t* TCling::BaseClassInfo_Factory(ClassInfo_t* cinfo) const
 BaseClassInfo_t* TCling::BaseClassInfo_Factory(ClassInfo_t* derived,
    ClassInfo_t* base) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    TClingClassInfo* TClinginfo = (TClingClassInfo*) derived;
    TClingClassInfo* TClinginfoBase = (TClingClassInfo*) base;
    return (BaseClassInfo_t*) new TClingBaseClassInfo(fInterpreter, TClinginfo, TClinginfoBase);
@@ -6668,6 +6676,7 @@ void TCling::DataMemberInfo_Delete(DataMemberInfo_t* dminfo) const
 //______________________________________________________________________________
 DataMemberInfo_t* TCling::DataMemberInfo_Factory(ClassInfo_t* clinfo /*= 0*/) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    TClingClassInfo* TClingclass_info = (TClingClassInfo*) clinfo;
    return (DataMemberInfo_t*) new TClingDataMemberInfo(fInterpreter, TClingclass_info);
 }
@@ -6675,6 +6684,7 @@ DataMemberInfo_t* TCling::DataMemberInfo_Factory(ClassInfo_t* clinfo /*= 0*/) co
 //______________________________________________________________________________
 DataMemberInfo_t* TCling::DataMemberInfo_Factory(DeclId_t declid, ClassInfo_t* clinfo) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    const clang::Decl* decl = reinterpret_cast<const clang::Decl*>(declid);
    const clang::ValueDecl* vd = llvm::dyn_cast_or_null<clang::ValueDecl>(decl);
    return (DataMemberInfo_t*) new TClingDataMemberInfo(fInterpreter, vd, (TClingClassInfo*)clinfo);
@@ -7018,12 +7028,14 @@ void TCling::MethodInfo_CreateSignature(MethodInfo_t* minfo, TString& signature)
 //______________________________________________________________________________
 MethodInfo_t* TCling::MethodInfo_Factory() const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    return (MethodInfo_t*) new TClingMethodInfo(fInterpreter);
 }
 
 //______________________________________________________________________________
 MethodInfo_t* TCling::MethodInfo_Factory(ClassInfo_t* clinfo) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    return (MethodInfo_t*) new TClingMethodInfo(fInterpreter, (TClingClassInfo*)clinfo);
 }
 
@@ -7031,6 +7043,7 @@ MethodInfo_t* TCling::MethodInfo_Factory(ClassInfo_t* clinfo) const
 MethodInfo_t* TCling::MethodInfo_Factory(DeclId_t declid) const
 {
    const clang::Decl* decl = reinterpret_cast<const clang::Decl*>(declid);
+   R__LOCKGUARD(gInterpreterMutex);
    const clang::FunctionDecl* fd = llvm::dyn_cast_or_null<clang::FunctionDecl>(decl);
    return (MethodInfo_t*) new TClingMethodInfo(fInterpreter, fd);
 }
@@ -7215,12 +7228,14 @@ void TCling::MethodArgInfo_Delete(MethodArgInfo_t* marginfo) const
 //______________________________________________________________________________
 MethodArgInfo_t* TCling::MethodArgInfo_Factory() const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    return (MethodArgInfo_t*) new TClingMethodArgInfo(fInterpreter);
 }
 
 //______________________________________________________________________________
 MethodArgInfo_t* TCling::MethodArgInfo_Factory(MethodInfo_t *minfo) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    return (MethodArgInfo_t*) new TClingMethodArgInfo(fInterpreter, (TClingMethodInfo*)minfo);
 }
 
@@ -7294,12 +7309,14 @@ void TCling::TypeInfo_Delete(TypeInfo_t* tinfo) const
 //______________________________________________________________________________
 TypeInfo_t* TCling::TypeInfo_Factory() const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    return (TypeInfo_t*) new TClingTypeInfo(fInterpreter);
 }
 
 //______________________________________________________________________________
 TypeInfo_t* TCling::TypeInfo_Factory(const char *name) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    return (TypeInfo_t*) new TClingTypeInfo(fInterpreter, name);
 }
 
@@ -7312,6 +7329,7 @@ TypeInfo_t* TCling::TypeInfo_FactoryCopy(TypeInfo_t* tinfo) const
 //______________________________________________________________________________
 void TCling::TypeInfo_Init(TypeInfo_t* tinfo, const char* name) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    TClingTypeInfo* TClinginfo = (TClingTypeInfo*) tinfo;
    TClinginfo->Init(name);
 }
@@ -7373,12 +7391,14 @@ void TCling::TypedefInfo_Delete(TypedefInfo_t* tinfo) const
 //______________________________________________________________________________
 TypedefInfo_t* TCling::TypedefInfo_Factory() const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    return (TypedefInfo_t*) new TClingTypedefInfo(fInterpreter);
 }
 
 //______________________________________________________________________________
 TypedefInfo_t* TCling::TypedefInfo_Factory(const char *name) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    return (TypedefInfo_t*) new TClingTypedefInfo(fInterpreter, name);
 }
 
@@ -7392,6 +7412,7 @@ TypedefInfo_t* TCling::TypedefInfo_FactoryCopy(TypedefInfo_t* tinfo) const
 void TCling::TypedefInfo_Init(TypedefInfo_t* tinfo,
                               const char* name) const
 {
+   R__LOCKGUARD(gInterpreterMutex);
    TClingTypedefInfo* TClinginfo = (TClingTypedefInfo*) tinfo;
    TClinginfo->Init(name);
 }

--- a/core/meta/src/TClingCallFunc.cxx
+++ b/core/meta/src/TClingCallFunc.cxx
@@ -2116,6 +2116,7 @@ void TClingCallFunc::exec_with_valref_return(void *address, cling::Value *ret) c
 
 void TClingCallFunc::EvaluateArgList(const string &ArgList)
 {
+   R__LOCKGUARD(gInterpreterMutex);
    SmallVector<Expr *, 4> exprs;
    fInterp->getLookupHelper().findArgList(ArgList, exprs,
                                           gDebug > 5 ? cling::LookupHelper::WithDiagnostics
@@ -2348,6 +2349,7 @@ void TClingCallFunc::ResetArg()
 
 void TClingCallFunc::SetArg(unsigned long param)
 {
+   R__LOCKGUARD(gInterpreterMutex);
    ASTContext &C = fInterp->getCI()->getASTContext();
    fArgVals.push_back(cling::Value(C.UnsignedLongTy, *fInterp));
    fArgVals.back().getLL() = param;
@@ -2355,6 +2357,7 @@ void TClingCallFunc::SetArg(unsigned long param)
 
 void TClingCallFunc::SetArg(long param)
 {
+   R__LOCKGUARD(gInterpreterMutex);
    ASTContext &C = fInterp->getCI()->getASTContext();
    fArgVals.push_back(cling::Value(C.LongTy, *fInterp));
    fArgVals.back().getLL() = param;
@@ -2362,6 +2365,7 @@ void TClingCallFunc::SetArg(long param)
 
 void TClingCallFunc::SetArg(float param)
 {
+   R__LOCKGUARD(gInterpreterMutex);
    ASTContext &C = fInterp->getCI()->getASTContext();
    fArgVals.push_back(cling::Value(C.FloatTy, *fInterp));
    fArgVals.back().getFloat() = param;
@@ -2369,6 +2373,7 @@ void TClingCallFunc::SetArg(float param)
 
 void TClingCallFunc::SetArg(double param)
 {
+   R__LOCKGUARD(gInterpreterMutex);
    ASTContext &C = fInterp->getCI()->getASTContext();
    fArgVals.push_back(cling::Value(C.DoubleTy, *fInterp));
    fArgVals.back().getDouble() = param;
@@ -2376,6 +2381,7 @@ void TClingCallFunc::SetArg(double param)
 
 void TClingCallFunc::SetArg(long long param)
 {
+   R__LOCKGUARD(gInterpreterMutex);
    ASTContext &C = fInterp->getCI()->getASTContext();
    fArgVals.push_back(cling::Value(C.LongLongTy, *fInterp));
    fArgVals.back().getLL() = param;
@@ -2383,6 +2389,7 @@ void TClingCallFunc::SetArg(long long param)
 
 void TClingCallFunc::SetArg(unsigned long long param)
 {
+   R__LOCKGUARD(gInterpreterMutex);
    ASTContext &C = fInterp->getCI()->getASTContext();
    fArgVals.push_back(cling::Value(C.UnsignedLongLongTy, *fInterp));
    fArgVals.back().getULL() = param;
@@ -2413,7 +2420,10 @@ void TClingCallFunc::SetFunc(const TClingClassInfo *info, const char *method, co
 {
    fWrapper = 0;
    delete fMethod;
-   fMethod = new TClingMethodInfo(fInterp);
+   {
+     R__LOCKGUARD(gInterpreterMutex);
+     fMethod = new TClingMethodInfo(fInterp);
+   }
    if (poffset) {
       *poffset = 0L;
    }
@@ -2442,7 +2452,10 @@ void TClingCallFunc::SetFunc(const TClingMethodInfo *info)
 {
    fWrapper = 0;
    delete fMethod;
-   fMethod = new TClingMethodInfo(*info);
+   {
+     R__LOCKGUARD(gInterpreterMutex);
+     fMethod = new TClingMethodInfo(*info);
+   }
    ResetArg();
    if (!fMethod->IsValid()) {
       return;
@@ -2462,7 +2475,10 @@ void TClingCallFunc::SetFuncProto(const TClingClassInfo *info, const char *metho
 {
    fWrapper = 0;
    delete fMethod;
-   fMethod = new TClingMethodInfo(fInterp);
+   {
+      R__LOCKGUARD(gInterpreterMutex);
+      fMethod = new TClingMethodInfo(fInterp);
+   }
    if (poffset) {
       *poffset = 0L;
    }
@@ -2492,7 +2508,10 @@ void TClingCallFunc::SetFuncProto(const TClingClassInfo *info, const char *metho
                                   EFunctionMatchMode mode/*=kConversionMatch*/)
 {
    delete fMethod;
-   fMethod = new TClingMethodInfo(fInterp);
+   {
+      R__LOCKGUARD(gInterpreterMutex);
+      fMethod = new TClingMethodInfo(fInterp);
+   }
    if (poffset) {
       *poffset = 0L;
    }

--- a/core/meta/src/TClingMethodInfo.cxx
+++ b/core/meta/src/TClingMethodInfo.cxx
@@ -163,7 +163,10 @@ void TClingMethodInfo::CreateSignature(TString &signature) const
       signature += ")";
       return;
    }
+
+   R__LOCKGUARD(gInterpreterMutex);
    TClingMethodArgInfo arg(fInterp, this);
+
    int idx = 0;
    while (arg.Next()) {
       if (idx) {
@@ -199,6 +202,7 @@ void *TClingMethodInfo::InterfaceMethod(const ROOT::TMetaUtils::TNormalizedCtxt 
    if (!IsValid()) {
       return 0;
    }
+   R__LOCKGUARD(gInterpreterMutex);   
    TClingCallFunc cf(fInterp,normCtxt);
    cf.SetFunc(this);
    return cf.InterfaceMethod();
@@ -209,6 +213,7 @@ bool TClingMethodInfo::IsValid() const
    if (fSingleDecl) return fSingleDecl;
    else if (fTemplateSpecIter) {
       // Could trigger deserialization of decls.
+      R__LOCKGUARD(gInterpreterMutex);
       cling::Interpreter::PushTransactionRAII RAII(fInterp);
       return *(*fTemplateSpecIter);
    }
@@ -278,6 +283,7 @@ int TClingMethodInfo::InternalNext()
          }
          clang::DeclContext *dc = fContexts[fContextIdx];
          // Could trigger deserialization of decls.
+
          cling::Interpreter::PushTransactionRAII RAII(fInterp);
          fIter = dc->decls_begin();
          if (*fIter) {

--- a/core/meta/src/TFunction.cxx
+++ b/core/meta/src/TFunction.cxx
@@ -279,7 +279,11 @@ Bool_t TFunction::Update(MethodInfo_t *info)
    // (info being the 'new' decl address).
 
    if (info == 0) {
-      if (fInfo) gCling->MethodInfo_Delete(fInfo);
+
+      if (fInfo) {
+         R__LOCKGUARD(gInterpreterMutex);
+         gCling->MethodInfo_Delete(fInfo);
+      }
       fInfo = 0;
       if (fMethodArgs) {
         for (Int_t i = 0; i < fMethodArgs->LastIndex() + 1; i ++) {
@@ -289,7 +293,10 @@ Bool_t TFunction::Update(MethodInfo_t *info)
       }
       return kTRUE;
    } else {
-      if (fInfo) gCling->MethodInfo_Delete(fInfo);
+      if (fInfo) {
+         R__LOCKGUARD(gInterpreterMutex);
+         gCling->MethodInfo_Delete(fInfo);
+      }
       fInfo = info;
       TString newMangledName = gCling->MethodInfo_GetMangledName(fInfo);
       if (newMangledName != fMangledName) {
@@ -302,6 +309,7 @@ Bool_t TFunction::Update(MethodInfo_t *info)
       if (fMethodArgs) {
          MethodArgInfo_t *arg = gCling->MethodArgInfo_Factory(fInfo);
          Int_t i = 0;
+         R__LOCKGUARD(gInterpreterMutex);
          while (gCling->MethodArgInfo_Next(arg)) {
             if (gCling->MethodArgInfo_IsValid(arg)) {
                MethodArgInfo_t *new_arg = gCling->MethodArgInfo_FactoryCopy(arg);


### PR DESCRIPTION
Need to take the interpreter lock for all cases where the cling
internals might be reached.

These fix threading problems related to TFormula.