### PR TITLE
Made calling TGenCollectionStreamer::Generate thread safe

### DIFF
--- a/io/io/inc/TGenCollectionProxy.h
+++ b/io/io/inc/TGenCollectionProxy.h
@@ -33,6 +33,9 @@
 #include "TCollectionProxyInfo.h"
 #endif
 
+#if __cplusplus >= 201103L
+#include <atomic>
+#endif
 #include <typeinfo>
 #include <string>
 #include <map>
@@ -325,7 +328,11 @@ protected:
    Feedfunc_t    fFeed;      // Container accessors: block feed
    Collectfunc_t fCollect;   // Method to collect objects from container
    Method0       fCreateEnv; // Method to allocate an Environment holder.
+#if __cplusplus >= 201103L
+   std::atomic<Value*> fValue;     // Descriptor of the container value type
+#else
    Value*        fValue;     // Descriptor of the container value type
+#endif
    Value*        fVal;       // Descriptor of the Value_type
    Value*        fKey;       // Descriptor of the key_type
    EnvironBase_t*fEnv;       // Address of the currently proxied object

--- a/io/io/src/TEmulatedCollectionProxy.cxx
+++ b/io/io/src/TEmulatedCollectionProxy.cxx
@@ -149,7 +149,7 @@ TGenCollectionProxy *TEmulatedCollectionProxy::InitializeEx(Bool_t silent)
                fValue = new Value(nam,silent);
                fKey   = new Value(inside[1],silent);
                fVal   = new Value(inside[2],silent);
-               if ( !fValue->IsValid() || !fKey->IsValid() || !fVal->IsValid() ) {
+               if ( !(*fValue).IsValid() || !fKey->IsValid() || !fVal->IsValid() ) {
                   return 0;
                }
                fPointers |= 0 != (fKey->fCase&G__BIT_ISPOINTER);
@@ -172,7 +172,7 @@ TGenCollectionProxy *TEmulatedCollectionProxy::InitializeEx(Bool_t silent)
             default:
                fValue = new Value(inside[1],silent);
                fVal   = new Value(*fValue);
-               if ( !fValue->IsValid() || !fVal->IsValid() ) {
+               if ( !(*fValue).IsValid() || !fVal->IsValid() ) {
                   return 0;
                }
                if ( 0 == fValDiff )  {

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -662,7 +662,7 @@ TGenCollectionProxy::~TGenCollectionProxy()
    clearVector(fProxyKept);
    clearVector(fStaged);
 
-   if ( fValue ) delete fValue;
+   if ( fValue ) delete fValue.load();
    if ( fVal   ) delete fVal;
    if ( fKey   ) delete fKey;
    
@@ -693,7 +693,7 @@ TVirtualCollectionProxy* TGenCollectionProxy::Generate() const
          return new TGenBitsetProxy(*this);
       }
       case TClassEdit::kVector: {
-         if (fValue->fKind == (EDataType)kBOOL_t) {
+         if ((*fValue).fKind == (EDataType)kBOOL_t) {
             return new TGenVectorBoolProxy(*this);
          } else {
             return new TGenVectorProxy(*this);
@@ -718,7 +718,6 @@ TGenCollectionProxy *TGenCollectionProxy::Initialize(Bool_t silent) const
    // Proxy initializer
    TGenCollectionProxy* p = const_cast<TGenCollectionProxy*>(this);
    if ( fValue ) return p;
-   const_cast<TGenCollectionProxy*>(this)->fProperties |= kIsInitialized;
    return p->InitializeEx(silent);
 }
 
@@ -786,6 +785,7 @@ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
       int num = TClassEdit::GetSplit(cl->GetName(),inside,nested);
       if ( num > 1 ) {
          std::string nam;
+         Value* newfValue = fValue;
          if ( inside[0].find("stdext::hash_") != std::string::npos )
             inside[0].replace(3,10,"::");
          if ( inside[0].find("__gnu_cxx::hash_") != std::string::npos )
@@ -807,7 +807,7 @@ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
             case TClassEdit::kMultiMap:
                nam = "pair<"+inside[1]+","+inside[2];
                nam += (nam[nam.length()-1]=='>') ? " >" : ">";
-               fValue = R__CreateValue(nam, silent);
+               newfValue = R__CreateValue(nam, silent);
                
                fVal   = R__CreateValue(inside[2], silent);
                fKey   = R__CreateValue(inside[1], silent);
@@ -829,9 +829,9 @@ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
                inside[1] = "bool";
                // Intentional fall through
             default:
-               fValue = R__CreateValue(inside[1], silent);
+               newfValue = R__CreateValue(inside[1], silent);
                
-               fVal   = new Value(*fValue);
+               fVal   = new Value(*newfValue);
                if ( 0 == fValDiff ) {
                   fValDiff = fVal->fSize;
                   fValDiff += (slong - fValDiff%slong)%slong;
@@ -844,6 +844,8 @@ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
             fProperties |= kNeedDelete;
          }
          fClass = cl;
+         //fValue must be set last since we use it to indicate that we are initialized
+         fValue = newfValue;
          return this;
       }
       Fatal("TGenCollectionProxy","Components of %s not analysed!",cl->GetName());
@@ -908,7 +910,7 @@ TClass *TGenCollectionProxy::GetValueClass() const
    // Return a pointer to the TClass representing the content.
 
    if (!fValue) Initialize(kFALSE);
-   return fValue ? fValue->fType.GetClass() : 0;
+   return fValue ? (*fValue).fType.GetClass() : 0;
 }
 
 //______________________________________________________________________________
@@ -917,7 +919,7 @@ void TGenCollectionProxy::SetValueClass(TClass *new_Value_type)
    // Set pointer to the TClass representing the content.
 
    if (!fValue) Initialize(kFALSE);
-   fValue->fType = new_Value_type;
+   (*fValue).fType = new_Value_type;
 }
 
 //______________________________________________________________________________
@@ -926,7 +928,7 @@ EDataType TGenCollectionProxy::GetType() const
    // If the content is a simple numerical value, return its type (see TDataType)
 
    if ( !fValue ) Initialize(kFALSE);
-   return fValue->fKind;
+   return (*fValue).fKind;
 }
 
 //______________________________________________________________________________

--- a/io/io/src/TGenCollectionStreamer.cxx
+++ b/io/io/src/TGenCollectionStreamer.cxx
@@ -58,7 +58,7 @@ TGenCollectionStreamer::~TGenCollectionStreamer()
 TVirtualCollectionProxy* TGenCollectionStreamer::Generate() const
 {
    // Virtual copy constructor.
-   if (!fClass) Initialize(kFALSE);
+   if (!fValue) Initialize(kFALSE);
    return new TGenCollectionStreamer(*this);
 }
 


### PR DESCRIPTION
Although each thread will get its own copy of TGenCollectionStreamer,
that copy is made by calling Generate on a global instance of the class.
Therefore Generate needs to be thread safe. This translates to requiring
TGenCollectionProxy::Initialize be thread safe. This required that
TGenCollectionProxy::fValue be atomic and be the last value to be set
in TGenCollectionProxy::InitializeEx.