### PR TITLE
Made calling TGenCollectionStreamer::Generate thread safe

### DIFF
--- a/io/io/inc/TGenCollectionProxy.h
+++ b/io/io/inc/TGenCollectionProxy.h
@@ -33,6 +33,7 @@
 #include "TCollectionProxyInfo.h"
 #endif
 
+#include <atomic>
 #include <typeinfo>
 #include <string>
 #include <map>
@@ -325,7 +326,7 @@ protected:
    Feedfunc_t    fFeed;      // Container accessors: block feed
    Collectfunc_t fCollect;   // Method to collect objects from container
    Method0       fCreateEnv; // Method to allocate an Environment holder.
-   Value*        fValue;     // Descriptor of the container value type
+   std::atomic<Value*> fValue;     // Descriptor of the container value type
    Value*        fVal;       // Descriptor of the Value_type
    Value*        fKey;       // Descriptor of the key_type
    EnvironBase_t*fEnv;       // Address of the currently proxied object

--- a/io/io/src/TEmulatedCollectionProxy.cxx
+++ b/io/io/src/TEmulatedCollectionProxy.cxx
@@ -149,7 +149,7 @@ TGenCollectionProxy *TEmulatedCollectionProxy::InitializeEx(Bool_t silent)
                fValue = new Value(nam,silent);
                fKey   = new Value(inside[1],silent);
                fVal   = new Value(inside[2],silent);
-               if ( !fValue->IsValid() || !fKey->IsValid() || !fVal->IsValid() ) {
+               if ( !(*fValue).IsValid() || !fKey->IsValid() || !fVal->IsValid() ) {
                   return 0;
                }
                fPointers |= 0 != (fKey->fCase&kIsPointer);
@@ -172,7 +172,7 @@ TGenCollectionProxy *TEmulatedCollectionProxy::InitializeEx(Bool_t silent)
             default:
                fValue = new Value(inside[1],silent);
                fVal   = new Value(*fValue);
-               if ( !fValue->IsValid() || !fVal->IsValid() ) {
+               if ( !(*fValue).IsValid() || !fVal->IsValid() ) {
                   return 0;
                }
                if ( 0 == fValDiff )  {

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -709,7 +709,7 @@ TGenCollectionProxy::~TGenCollectionProxy()
    clearVector(fProxyKept);
    clearVector(fStaged);
 
-   if ( fValue ) delete fValue;
+   if ( fValue ) delete fValue.load();
    if ( fVal   ) delete fVal;
    if ( fKey   ) delete fKey;
 
@@ -740,7 +740,7 @@ TVirtualCollectionProxy* TGenCollectionProxy::Generate() const
          return new TGenBitsetProxy(*this);
       }
       case ROOT::kSTLvector: {
-         if (fValue->fKind == (EDataType)kBOOL_t) {
+         if ((*fValue).fKind == (EDataType)kBOOL_t) {
             return new TGenVectorBoolProxy(*this);
          } else {
             return new TGenVectorProxy(*this);
@@ -765,7 +765,6 @@ TGenCollectionProxy *TGenCollectionProxy::Initialize(Bool_t silent) const
    // Proxy initializer
    TGenCollectionProxy* p = const_cast<TGenCollectionProxy*>(this);
    if ( fValue ) return p;
-   const_cast<TGenCollectionProxy*>(this)->fProperties |= kIsInitialized;
    return p->InitializeEx(silent);
 }
 
@@ -833,6 +832,7 @@ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
       int num = TClassEdit::GetSplit(cl->GetName(),inside,nested);
       if ( num > 1 ) {
          std::string nam;
+         Value* newfValue = fValue;
          if ( inside[0].find("stdext::hash_") != std::string::npos )
             inside[0].replace(3,10,"::");
          if ( inside[0].find("__gnu_cxx::hash_") != std::string::npos )
@@ -854,7 +854,7 @@ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
             case ROOT::kSTLmultimap:
                nam = "pair<"+inside[1]+","+inside[2];
                nam += (nam[nam.length()-1]=='>') ? " >" : ">";
-               fValue = R__CreateValue(nam, silent);
+               newfValue = R__CreateValue(nam, silent);
 
                fVal   = R__CreateValue(inside[2], silent);
                fKey   = R__CreateValue(inside[1], silent);
@@ -876,7 +876,7 @@ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
                inside[1] = "bool";
                // Intentional fall through
             default:
-               fValue = R__CreateValue(inside[1], silent);
+               newfValue = R__CreateValue(inside[1], silent);
 
                fVal   = new Value(*fValue);
                if ( 0 == fValDiff ) {
@@ -891,6 +891,8 @@ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
             fProperties |= kNeedDelete;
          }
          fClass = cl;
+         //fValue must be set last since we use it to indicate that we are initialized
+         fValue = newfValue;
          return this;
       }
       Fatal("TGenCollectionProxy","Components of %s not analysed!",cl->GetName());
@@ -955,7 +957,7 @@ TClass *TGenCollectionProxy::GetValueClass() const
    // Return a pointer to the TClass representing the content.
 
    if (!fValue) Initialize(kFALSE);
-   return fValue ? fValue->fType.GetClass() : 0;
+   return fValue ? (*fValue).fType.GetClass() : 0;
 }
 
 //______________________________________________________________________________
@@ -967,9 +969,9 @@ void TGenCollectionProxy::UpdateValueClass(const TClass *oldValueType, TClass *n
    // Note that we do not need to update anything if we have not yet been
    // initialized.  In addition (see ROOT-6040) doing an initialization here
    // might hence a nested dlopen (due to autoloading).
-   if (fValue && fValue->fType == oldValueType) {
+   if (fValue && (*fValue).fType == oldValueType) {
       // Set pointer to the TClass representing the content.
-      fValue->fType = newValueType;
+      (*fValue).fType = newValueType;
    }
 }
 
@@ -979,7 +981,7 @@ EDataType TGenCollectionProxy::GetType() const
    // If the content is a simple numerical value, return its type (see TDataType)
 
    if ( !fValue ) Initialize(kFALSE);
-   return fValue->fKind;
+   return (*fValue).fKind;
 }
 
 //______________________________________________________________________________

--- a/io/io/src/TGenCollectionStreamer.cxx
+++ b/io/io/src/TGenCollectionStreamer.cxx
@@ -58,7 +58,7 @@ TGenCollectionStreamer::~TGenCollectionStreamer()
 TVirtualCollectionProxy* TGenCollectionStreamer::Generate() const
 {
    // Virtual copy constructor.
-   if (!fClass) Initialize(kFALSE);
+   if (!fValue) Initialize(kFALSE);
    return new TGenCollectionStreamer(*this);
 }
 


### PR DESCRIPTION
Although each thread will get its own copy of TGenCollectionStreamer,
that copy is made by calling Generate on a global instance of the class.
Therefore Generate needs to be thread safe. This translates to requiring
TGenCollectionProxy::Initialize be thread safe. This required that
TGenCollectionProxy::fValue be atomic and be the last value to be set
in TGenCollectionProxy::InitializeEx.