### PR TITLE
Forward port of Vincenzo's SMatrix speed up.

### DIFF
--- a/core/metautils/src/SelectionRules.cxx
+++ b/core/metautils/src/SelectionRules.cxx
@@ -305,7 +305,7 @@ const ClassSelectionRule *SelectionRules::IsDeclSelected(clang::NamespaceDecl *D
 }
 
 const BaseSelectionRule *SelectionRules::IsDeclSelected(clang::EnumDecl *D) const
-{  
+{
    // Currently rootcling does not need any information on enums, except
    // for the PCM / proto classes that register them to build TEnums without
    // parsing. This can be removed once (real) PCMs are available.
@@ -866,7 +866,9 @@ const BaseSelectionRule *SelectionRules::IsVarSelected(clang::VarDecl* D, const 
 
 const BaseSelectionRule *SelectionRules::IsFunSelected(clang::FunctionDecl *D, const std::string &qual_name) const
 {
+
    if (fFunctionSelectionRules.size() == 0 ||
+       D->getPrimaryTemplate() != nullptr ||
        llvm::isa<clang::CXXMethodDecl>(D)) return nullptr;
 
    std::string prototype;
@@ -974,6 +976,7 @@ const BaseSelectionRule *SelectionRules::IsLinkdefFunSelected(clang::FunctionDec
 {
 
    if (fFunctionSelectionRules.size() == 0 ||
+       D->getPrimaryTemplate() != nullptr ||
        llvm::isa<clang::CXXMethodDecl>(D)) return nullptr;
 
    std::string prototype;

--- a/math/smatrix/inc/Math/SMatrix.h
+++ b/math/smatrix/inc/Math/SMatrix.h
@@ -97,6 +97,7 @@ namespace Math {
 template <class T, unsigned int D> class SVector;
 
 struct SMatrixIdentity { };
+struct SMatrixNoInit { };
 
 //__________________________________________________________________________
 /**
@@ -149,6 +150,11 @@ public:
    */
    SMatrix();
    ///
+  /**
+       construct from without initialization
+   */
+   inline SMatrix( SMatrixNoInit ){}
+
    /**
        construct from an identity matrix
    */


### PR DESCRIPTION
This is the complete set of changes required for the SMatrix speedup. Previous set of changes were missing 2e1a794af3f186562a97650ffcd0368233d95b70 from Danilo. Since we moved to the `HEAD` of the patches branch I'm assuming we will not backport this to `cms/v6-02-05`.