### PR TITLE
Fix from Philippe Canal for problem with transient data members with iorules

### DIFF
--- a/core/meta/inc/TStreamerElement.h
+++ b/core/meta/inc/TStreamerElement.h
@@ -112,6 +112,7 @@ public:
    virtual Bool_t   HasCounter() const {return kFALSE;}
    virtual Bool_t   IsOldFormat(const char *newTypeName);
    virtual Bool_t   IsBase() const;
+   virtual Bool_t   IsTransient() const;
    virtual void     ls(Option_t *option="") const;
    virtual void     SetArrayDim(Int_t dim);
    virtual void     SetMaxIndex(Int_t dim, Int_t max);

--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -434,6 +434,25 @@ Bool_t TStreamerElement::IsBase() const
 }
 
 //______________________________________________________________________________
+Bool_t TStreamerElement::IsTransient() const
+{
+   // Return kTRUE if the element represent an entity that is not written
+   // to the disk (transient members, cache allocator/deallocator, etc.)
+
+   if (fType == TVirtualStreamerInfo::kArtificial) {
+      // if (((const TStreamerArtificial*)this)->GetWriteFunc() == 0)
+         return kTRUE;
+   }
+   if (fType == TVirtualStreamerInfo::kCacheNew) return kTRUE;
+   if (fType == TVirtualStreamerInfo::kCacheDelete) return kTRUE;
+   if (fType == TVirtualStreamerInfo::kCache) return kTRUE;
+   if (fType == TVirtualStreamerInfo::kMissing) return kTRUE;
+   if (TVirtualStreamerInfo::kSkip <= fType && fType < TVirtualStreamerInfo::kSkip) return kTRUE;
+
+   return kFALSE;
+}
+
+//______________________________________________________________________________
 void TStreamerElement::ls(Option_t *) const
 {
    // Print the content of the element.

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2988,6 +2988,7 @@ void TStreamerInfo::ForceWriteInfo(TFile* file, Bool_t force)
    TIter next(fElements);
    TStreamerElement* element = (TStreamerElement*) next();
    for (; element; element = (TStreamerElement*) next()) {
+      if (element->IsTransient()) continue;
       TClass* cl = element->GetClassPointer();
       if (cl) {
          TVirtualStreamerInfo* si = 0;

--- a/io/io/src/TStreamerInfoWriteBuffer.cxx
+++ b/io/io/src/TStreamerInfoWriteBuffer.cxx
@@ -782,7 +782,7 @@ Int_t TStreamerInfo::WriteBufferAux(TBuffer &b, const T &arr,
             continue;
          case TStreamerInfo::kArtificial:
 #if 0
-            ROOT::TSchemaRule::WriteFuncPtr_t writefunc = ((TStreamerArtificialElement*)aElement)->GetWriteFunc();
+            ROOT::TSchemaRule::WriteFuncPtr_t writefunc = ((TStreamerArtificial*)aElement)->GetWriteFunc();
             if (writefunc) {
                DOLOOP( writefunc(arr[k]+eoffset, b) );
             }


### PR DESCRIPTION
This fixes a problem where a transient data member is of type ```std::atomic<const void*>```.