### PR TITLE
Support TTree with more than 32766 branch in TTreeFormula.

### DIFF
--- a/tree/treeplayer/inc/TTreeFormula.h
+++ b/tree/treeplayer/inc/TTreeFormula.h
@@ -90,7 +90,7 @@ protected:
    };
 
    TTree       *fTree;            //! pointer to Tree
-   Short_t     fCodes[kMAXCODES]; //  List of leaf numbers referenced in formula
+   Int_t        fCodes[kMAXCODES]; //  List of leaf numbers referenced in formula
    Int_t       fNdata[kMAXCODES]; //! This caches the physical number of element in the leaf or datamember.
    Int_t       fNcodes;           //  Number of leaves referenced in formula
    Bool_t      fHasCast;          //  Record whether the formula contain a cast operation or not


### PR DESCRIPTION
The limit is now the same as the location (index need to fit in a signed integer).
This is since in a real use case where the TTree has a total of 34879 (sub)branches.