### PR TITLE
Resolve ASan reports (user-after-free) in TClass and TCling

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -2835,9 +2835,9 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent)
       if (!loadedcl){
          if (TDataType* theDataType = gROOT->GetType(normalizedName.c_str())){
             // We have a typedef: we get the name of the underlying type
-            auto underlyingTypeName = theDataType->GetTypeName().Data();
+            auto underlyingTypeName = theDataType->GetTypeName();
             // We see if we can bootstrap a class with it
-            auto underlyingTypeDict = TClassTable::GetDictNorm(underlyingTypeName);
+            auto underlyingTypeDict = TClassTable::GetDictNorm(underlyingTypeName.Data());
             if (underlyingTypeDict){
                loadedcl = underlyingTypeDict();
             }

--- a/core/meta/src/TCling.cxx
+++ b/core/meta/src/TCling.cxx
@@ -5283,8 +5283,8 @@ void TCling::UpdateClassInfoWithDecl(const void* vTD)
       }
       clang::QualType type( td->getTypeForDecl(), 0 );
 
-      auto declName=ND->getNameAsString().c_str();
-      if (!TClass::HasNoInfoOrEmuOrFwdDeclaredDecl(declName)){
+      auto declName = ND->getNameAsString();
+      if (!TClass::HasNoInfoOrEmuOrFwdDeclaredDecl(declName.c_str())){
 //          printf ("Impossible to find a TClassEntry in kNoInfo or kEmulated the decl of which would be called %s. Skip w/o building the normalized name.\n",declName );
          return;
       }


### PR DESCRIPTION
The following were found while compiling CMSSW + GCC 4.9.1 + ASan. These two resolves enough issues in ROOT6 to compile CMSSW + ASan.

Cherry-pick from official ROOT repository.