### PR TITLE
Use a lock to protect access to collection from TROOT::GetListOfCleanups

### DIFF
--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -48,6 +48,7 @@
 #include "TObjString.h"
 #include "TRefTable.h"
 #include "TProcessID.h"
+#include "TVirtualMutex.h"
 
 Long_t TObject::fgDtorOnly = 0;
 Bool_t TObject::fgObjectStat = kTRUE;
@@ -144,6 +145,7 @@ TObject::~TObject()
       if (root->MustClean()) {
          if (root == this) return;
          if (TestBit(kMustCleanup)) {
+            R__LOCKGUARD2(gROOTMutex);
             root->GetListOfCleanups()->RecursiveRemove(this);
          }
       }

--- a/core/base/src/TObjectSpy.cxx
+++ b/core/base/src/TObjectSpy.cxx
@@ -11,7 +11,7 @@
 
 #include "TObjectSpy.h"
 #include "TROOT.h"
-
+#include "TVirtualMutex.h"
 
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
@@ -36,6 +36,7 @@ TObjectSpy::TObjectSpy(TObject *obj, Bool_t fixMustCleanupBit) :
    // kMustCleanup bit set. If the object has been deleted during a
    // RecusiveRemove() operation, GetObject() will return 0.
 
+   R__LOCKGUARD2(gROOTMutex);
    gROOT->GetListOfCleanups()->Add(this);
    if (fObj && !fObj->TestBit(kMustCleanup)) {
       if (fixMustCleanupBit) {
@@ -54,6 +55,7 @@ TObjectSpy::~TObjectSpy()
 
    if (fObj && fResetMustCleanupBit)
       fObj->SetBit(kMustCleanup, kFALSE);
+   R__LOCKGUARD2(gROOTMutex);
    gROOT->GetListOfCleanups()->Remove(this);
 }
 
@@ -99,6 +101,7 @@ TObjectRefSpy::TObjectRefSpy(TObject *&obj, Bool_t fixMustCleanupBit) :
    // kMustCleanup bit set. If the object has been deleted during a
    // RecusiveRemove() operation, GetObject() will return 0.
 
+   R__LOCKGUARD2(gROOTMutex);
    gROOT->GetListOfCleanups()->Add(this);
    if (fObj && !fObj->TestBit(kMustCleanup)) {
       if (fixMustCleanupBit) {
@@ -117,6 +120,7 @@ TObjectRefSpy::~TObjectRefSpy()
 
    if (fObj && fResetMustCleanupBit)
       fObj->SetBit(kMustCleanup, kFALSE);
+   R__LOCKGUARD2(gROOTMutex);
    gROOT->GetListOfCleanups()->Remove(this);
 }
 

--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -23,6 +23,7 @@
 #include "TBrowser.h"
 #include "TMath.h"
 #include "TObjString.h"
+#include "TVirtualMutex.h"
 
 ClassImp(THStack)
 
@@ -80,6 +81,7 @@ THStack::THStack(const char *name, const char *title)
    fHistogram = 0;
    fMaximum   = -1111;
    fMinimum   = -1111;
+   R__LOCKGUARD2(gROOTMutex);
    gROOT->GetListOfCleanups()->Add(this);
 }
 
@@ -122,8 +124,10 @@ THStack::THStack(TH1* hist, Option_t *axis /*="x"*/,
    fHistogram = 0;
    fMaximum   = -1111;
    fMinimum   = -1111;
-   gROOT->GetListOfCleanups()->Add(this);
-
+   {
+      R__LOCKGUARD2(gROOTMutex);
+      gROOT->GetListOfCleanups()->Add(this);
+   }
    if (!axis) {
       Warning("THStack", "Need an axis.");
       return;
@@ -266,7 +270,10 @@ THStack::~THStack()
 // THStack destructor
 
 
-   gROOT->GetListOfCleanups()->Remove(this);
+   {
+      R__LOCKGUARD2(gROOTMutex);
+      gROOT->GetListOfCleanups()->Remove(this);
+   }
    if (!fHists) return;
    fHists->Clear("nodelete");
    delete fHists;

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -40,6 +40,7 @@
 #include "TClassRef.h"
 #include "TROOT.h"
 #include "TMemFile.h"
+#include "TVirtualMutex.h"
 
 #ifdef WIN32
 // For _getmaxstdio
@@ -99,6 +100,7 @@ TFileMerger::TFileMerger(Bool_t isLocal, Bool_t histoOneGo)
    fExcessFiles = new TList;
    fExcessFiles->SetOwner(kTRUE);
 
+   R__LOCKGUARD2(gROOTMutex);
    gROOT->GetListOfCleanups()->Add(this);
 }
 
@@ -107,7 +109,10 @@ TFileMerger::~TFileMerger()
 {
    // Cleanup.
 
-   gROOT->GetListOfCleanups()->Remove(this);
+   {
+      R__LOCKGUARD2(gROOTMutex);
+      gROOT->GetListOfCleanups()->Remove(this);
+   }
    SafeDelete(fFileList);
    SafeDelete(fMergeList);
    SafeDelete(fOutputFile);

--- a/net/http/src/TRootSniffer.cxx
+++ b/net/http/src/TRootSniffer.cxx
@@ -32,6 +32,7 @@
 #include "TUrl.h"
 #include "TImage.h"
 #include "RZip.h"
+#include "TVirtualMutex.h"
 
 #include "TRootSnifferStore.h"
 
@@ -1473,9 +1474,11 @@ Bool_t TRootSniffer::RegisterObject(const char *subfolder, TObject *obj)
    dabcfold->Add(obj);
 
    // register folder for cleanup
-   if (!gROOT->GetListOfCleanups()->FindObject(dabcfold))
-      gROOT->GetListOfCleanups()->Add(dabcfold);
-
+   {
+      R__LOCKGUARD2(gROOTMutex);
+      if (!gROOT->GetListOfCleanups()->FindObject(dabcfold))
+         gROOT->GetListOfCleanups()->Add(dabcfold);
+   }
    return kTRUE;
 }
 

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -55,6 +55,7 @@
 #include "TEntryListFromFile.h"
 #include "TFileStager.h"
 #include "TFilePrefetch.h"
+#include "TVirtualMutex.h"
 
 const Long64_t theBigNumber = Long64_t(1234567890)<<28;
 
@@ -93,6 +94,7 @@ TChain::TChain()
    gROOT->GetListOfDataSets()->Add(this);
 
    // Make sure we are informed if the TFile is deleted.
+   R__LOCKGUARD2(gROOTMutex);
    gROOT->GetListOfCleanups()->Add(this);
 }
 
@@ -164,6 +166,7 @@ TChain::TChain(const char* name, const char* title)
    gROOT->GetListOfDataSets()->Add(this);
 
    // Make sure we are informed if the TFile is deleted.
+   R__LOCKGUARD2(gROOTMutex);
    gROOT->GetListOfCleanups()->Add(this);
 }
 
@@ -171,7 +174,10 @@ TChain::TChain(const char* name, const char* title)
 TChain::~TChain()
 {
    // -- Destructor.
-   gROOT->GetListOfCleanups()->Remove(this);
+   {
+      R__LOCKGUARD2(gROOTMutex);
+      gROOT->GetListOfCleanups()->Remove(this);
+   }
 
    SafeDelete(fProofChain);
    fStatus->Delete();
@@ -2783,7 +2789,10 @@ void TChain::Streamer(TBuffer& b)
 
    if (b.IsReading()) {
       // Remove using the 'old' name.
-      gROOT->GetListOfCleanups()->Remove(this);
+      {
+         R__LOCKGUARD2(gROOTMutex);
+         gROOT->GetListOfCleanups()->Remove(this);
+      }
 
       UInt_t R__s, R__c;
       Version_t R__v = b.ReadVersion(&R__s, &R__c);
@@ -2804,7 +2813,10 @@ void TChain::Streamer(TBuffer& b)
          //====end of old versions
       }
       // Re-add using the new name.
-      gROOT->GetListOfCleanups()->Add(this);
+      {
+         R__LOCKGUARD2(gROOTMutex);
+         gROOT->GetListOfCleanups()->Add(this);
+      }
 
    } else {
       b.WriteClassBuffer(TChain::Class(),this);

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -367,6 +367,7 @@
 #include "TBranchSTL.h"
 #include "TSchemaRuleSet.h"
 #include "TFileMergeInfo.h"
+#include "TVirtualMutex.h"
 
 #include <cstddef>
 #include <fstream>
@@ -836,7 +837,10 @@ TTree::~TTree()
    }
    if (fClones) {
       // Clone trees should no longer be removed from fClones when they are deleted.
-      gROOT->GetListOfCleanups()->Remove(fClones);
+     {
+        R__LOCKGUARD2(gROOTMutex);
+        gROOT->GetListOfCleanups()->Remove(fClones);
+     }
       // Note: fClones does not own its content.
       delete fClones;
       fClones = 0;
@@ -989,7 +993,10 @@ void TTree::AddClone(TTree* clone)
       fClones->SetOwner(false);
       // So that the clones are automatically removed from the list when
       // they are deleted.
-      gROOT->GetListOfCleanups()->Add(fClones);
+      {
+         R__LOCKGUARD2(gROOTMutex);
+         gROOT->GetListOfCleanups()->Add(fClones);
+      }
    }
    if (!fClones->FindObject(clone)) {
       fClones->Add(clone);

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -77,6 +77,7 @@
 #include "TVirtualMonitoring.h"
 #include "TTreeCache.h"
 #include "TStyle.h"
+#include "TVirtualMutex.h"
 
 #include "HFitInterface.h"
 #include "Foption.h"
@@ -112,7 +113,10 @@ TTreePlayer::TTreePlayer()
    fInput->Add(new TNamed("varexp",""));
    fInput->Add(new TNamed("selection",""));
    fSelector->SetInputList(fInput);
-   gROOT->GetListOfCleanups()->Add(this);
+   {
+      R__LOCKGUARD2(gROOTMutex);
+      gROOT->GetListOfCleanups()->Add(this);
+   }
    TClass::GetClass("TRef")->AdoptReferenceProxy(new TRefProxy());
    TClass::GetClass("TRefArray")->AdoptReferenceProxy(new TRefArrayProxy());
 }
@@ -128,6 +132,7 @@ TTreePlayer::~TTreePlayer()
    DeleteSelectorFromFile();
    fInput->Delete();
    delete fInput;
+   R__LOCKGUARD2(gROOTMutex);
    gROOT->GetListOfCleanups()->Remove(this);
 }
 


### PR DESCRIPTION
The protection of the collection returned from TROOT::GetListOfCleanups()
was insufficient since thread related crashes could still occur. This
commit protects all uses except for those from the GUI.

This should fix the crashes seen in CMSSW_7_5_THREADED_X IB RelVals.