### PR TITLE
Work around ROOT-6966 to unblock CMS and ATLAS: do not validate arch.

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
@@ -2505,7 +2505,9 @@ ASTReader::ReadControlBlock(ModuleFile &F,
     }
 
     case TARGET_OPTIONS: {
-      bool Complain = (ClientLoadCapabilities & ARR_ConfigurationMismatch)==0;
+      // Work around ROOT-6966
+      //bool Complain = (ClientLoadCapabilities & ARR_ConfigurationMismatch)==0;
+      bool Complain = false;
       if (Listener && &F == *ModuleMgr.begin() &&
           ParseTargetOptions(Record, Complain, *Listener) &&
           !DisableValidation && !AllowConfigurationMismatch)


### PR DESCRIPTION
The "proper" fix will be to use the architecture from the PCH as the architecture of the interpreter.

(cherry picked from commit 94dbfd1337db36490c3ff3a65215b677e7873b05)