### PR TITLE
Shrink buffers when requested.

### DIFF
--- a/core/base/src/TBuffer.cxx
+++ b/core/base/src/TBuffer.cxx
@@ -200,7 +200,7 @@ void TBuffer::Expand(Int_t newsize, Bool_t copy)
    // the requested size, we only shrink down to the current length.
 
    Int_t l  = Length();
-   if ( l > newsize ) {
+   if ( (l > newsize) && copy ) {
       newsize = l;
    }
    if ( (fMode&kWrite)!=0 ) {


### PR DESCRIPTION
If we're not copying data forward, shrink as requested.

@davidlange6 - this should allow us to shrink output buffers again.