### PR TITLE
Fix type printing of array template args

### DIFF
--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -48,6 +48,7 @@ class hierarchies (watch out for overlaps).
 #include "TObjString.h"
 #include "TRefTable.h"
 #include "TProcessID.h"
+#include "TVirtualMutex.h"
 
 Long_t TObject::fgDtorOnly = 0;
 Bool_t TObject::fgObjectStat = kTRUE;
@@ -85,6 +86,7 @@ TObject::~TObject()
       if (root->MustClean()) {
          if (root == this) return;
          if (TestBit(kMustCleanup)) {
+            R__LOCKGUARD2(gROOTMutex);
             root->GetListOfCleanups()->RecursiveRemove(this);
          }
       }

--- a/interpreter/llvm/src/tools/clang/lib/AST/TemplateBase.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/AST/TemplateBase.cpp
@@ -398,9 +398,22 @@ void TemplateArgument::print(const PrintingPolicy &Policy,
     
   case Declaration: {
     NamedDecl *ND = cast<NamedDecl>(getAsDecl());
-    Out << '&';
+    bool needsRef = true;
+    if (auto VD = dyn_cast<ValueDecl>(ND)) {
+      const clang::Type *ArgTy = VD->getType()->getUnqualifiedDesugaredType();
+      const clang::Type *ParmTy
+        = getParamTypeForDecl()->getUnqualifiedDesugaredType();
+      clang::ASTContext& Ctx = ND->getASTContext();
+      needsRef = !Ctx.hasSameType(ArgTy, ParmTy);
+      if (needsRef && (ArgTy->isArrayType() || ArgTy->isFunctionType())) {
+        const clang::Type *decayedArgTy
+          = Ctx.getDecayedType(clang::QualType(ArgTy, 0)).getTypePtr();
+        needsRef = !Ctx.hasSameType(decayedArgTy, ParmTy);
+      }
+    }
+    if (needsRef)
+      Out << '&';
     if (ND->getDeclName()) {
-      // FIXME: distinguish between pointer and reference args?
       ND->printQualifiedName(Out);
     } else {
       Out << "(anonymous)";


### PR DESCRIPTION
Apply patch to interpreter/llvm/src/tools/clang/lib/AST/TemplateBase.cpp as suggested here:
https://reviews.llvm.org/D36368