### PR TITLE
Double the TMVA xmlenginebuffersize to test large file parsing

### DIFF
--- a/tmva/tmva/inc/TMVA/Tools.h
+++ b/tmva/tmva/inc/TMVA/Tools.h
@@ -268,7 +268,7 @@ namespace TMVA {
       const char* GetName     ( void* node );
 
       TXMLEngine& xmlengine() { return *fXMLEngine; }
-      int xmlenginebuffersize() { return 10000000; }
+      int xmlenginebuffersize() { return 20000000; }
       TXMLEngine* fXMLEngine;
 
       TH1*       GetCumulativeDist( TH1* h);


### PR DESCRIPTION
Test of TMVA with doubled xmlenginebuffersize for large xml file parsing, suggested as possible solution to the problem discussed in https://github.com/cms-sw/cmssw/issues/26154 . This follow the comment https://github.com/cms-sw/cmssw/issues/26154#issuecomment-472343434 and subsequent discussion.