### PR TITLE
Disable rdict files

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -1801,6 +1801,85 @@ void ROOT::TMetaUtils::WriteClassInit(std::ostream& finalString,
 
    finalString << "   static TGenericClassInfo *GenerateInitInstanceLocal(const " << csymbol << "*)" << "\n" << "   {" << "\n";
 
+   /* If the attribute "comment" is present for data members, trigger the manipulaition of
+    * the decls.
+    * 1) Seek the decl of the class thanks to the interpreter
+    * 2) Annotate the decl with the value of the comment
+    */
+
+   std::string attribute_s,attrName, attrValue;
+   bool infrastructureGenerated=false;
+   for(clang::CXXRecordDecl::decl_iterator internalDeclIt = decl->decls_begin();
+       internalDeclIt != decl->decls_end(); ++internalDeclIt){
+
+      clang::FieldDecl* dMember = clang::dyn_cast<clang::FieldDecl>(*internalDeclIt);
+      // Check if this is a field and if it has any attribute
+      if (!dMember || (dMember && !dMember->hasAttrs())) continue;
+
+      bool blockNeedsToBeClosed=true;
+      bool preceedingWasIO = false;
+      // Now loop on its attributes
+      for (clang::Decl::attr_iterator attrIt = internalDeclIt->attr_begin();
+           attrIt!=internalDeclIt->attr_end();++attrIt){
+
+         // Get the attribute as string
+         if (0!=ROOT::TMetaUtils::extractAttrString(*attrIt,attribute_s)) continue;
+
+         // Split in name value
+         if (0!=ROOT::TMetaUtils::extractPropertyNameValFromString(attribute_s, attrName, attrValue)) continue;
+
+         bool isIoName =  attrName == propNames::ioname;
+         bool isIoType =  attrName == propNames::iotype;
+         bool isComment =  attrName == propNames::comment;
+         bool isRelevant = isIoName || isIoType || isComment;
+
+         // Check if this is a "comment", "ioname" or "iotype"
+
+         if (! isRelevant) continue;
+
+         // If this is not a comment, we must add the key-value pair
+         if (!isComment)
+            attrValue = attrName + propNames::separator + attrValue;
+
+         if (!infrastructureGenerated){
+            finalString << "      static bool firstCall = true;\n"
+                        << "      if (gInterpreter && !firstCall){\n"
+                        << "         Int_t prevAutoLoad = gInterpreter->SetClassAutoloading(0);\n"
+                        << "         ClassInfo_t* CI = gInterpreter->ClassInfo_Factory(\"" << classname << "\");\n"
+                        << "         DataMemberInfo_t *DMI = gInterpreter->DataMemberInfo_Factory(CI);\n"
+                        << "         while (gInterpreter->DataMemberInfo_Next(DMI)) {\n";
+            infrastructureGenerated=true;
+         }
+
+         if ( ! (preceedingWasIO) ){
+            const std::string memberName(dMember->getName());
+            finalString << "             if (!strcmp(\"" << memberName << "\", gInterpreter->DataMemberInfo_Name(DMI))){\n";
+         }
+         finalString << "                gInterpreter->SetDeclAttr(gInterpreter->GetDeclId(DMI),\"" << attrValue << "\");\n";
+
+         if ( isComment || preceedingWasIO ){
+            finalString << "             }\n";
+            blockNeedsToBeClosed = false;
+         }
+
+         preceedingWasIO = isIoType || isIoName ;
+
+      } // end loop on annotations of the decl
+
+      if (blockNeedsToBeClosed && preceedingWasIO){
+         finalString << "             }\n";
+      }
+
+   } // end loop on class internal decls
+
+   if (infrastructureGenerated) {
+      finalString << "         }\n"
+                  << "         gInterpreter->SetClassAutoloading(prevAutoLoad);\n"
+                  << "      }\n"
+                  << "      firstCall=false; \n";
+   }
+
+
    finalString << "      " << csymbol << " *ptr = 0;" << "\n";
 
    //fprintf(fp, "      static ::ROOT::ClassInfo< %s > \n",classname.c_str());

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -2092,16 +2092,16 @@ void TCling::RegisterModule(const char* modulename,
       }
    }
 
-   if (gIgnoredPCMNames.find(modulename) == gIgnoredPCMNames.end()) {
-      llvm::SmallString<256> pcmFileNameFullPath(dyLibName);
-      // The path dyLibName might not be absolute. This can happen if dyLibName
-      // is linked to an executable in the same folder.
-      llvm::sys::fs::make_absolute(pcmFileNameFullPath);
-      llvm::sys::path::remove_filename(pcmFileNameFullPath);
-      llvm::sys::path::append(pcmFileNameFullPath,
-                              ROOT::TMetaUtils::GetModuleFileName(modulename));
-      LoadPCM(pcmFileNameFullPath.str().str());
-   }
+   // if (gIgnoredPCMNames.find(modulename) == gIgnoredPCMNames.end()) {
+   //    llvm::SmallString<256> pcmFileNameFullPath(dyLibName);
+   //    // The path dyLibName might not be absolute. This can happen if dyLibName
+   //    // is linked to an executable in the same folder.
+   //    llvm::sys::fs::make_absolute(pcmFileNameFullPath);
+   //    llvm::sys::path::remove_filename(pcmFileNameFullPath);
+   //    llvm::sys::path::append(pcmFileNameFullPath,
+   //                            ROOT::TMetaUtils::GetModuleFileName(modulename));
+   //    LoadPCM(pcmFileNameFullPath.str().str());
+   // }
 
    { // scope within which diagnostics are de-activated
    // For now we disable diagnostics because we saw them already at

--- a/interpreter/cling/.travis.yml
+++ b/interpreter/cling/.travis.yml
@@ -100,12 +100,10 @@ matrix:
       compiler: clang
 
     - os: linux
-      env: CXXLIB=libstdc++ COMPILER=clang++-5.0 CCOMPILER=clang-5.0
+      env: CXXLIB=libstdc++ COMPILER=clang++ CCOMPILER=clang
       addons:
         apt:
-          sources: llvm-toolchain-trusty-5.0
-          packages: clang-5.0
-      compiler: clang-5.0
+      compiler: clang
 
 #  allow_failures:
 #    # clang-3.5 crashes compiling clang-3.9 with libc++-3.9

--- a/interpreter/cling/.travis.yml
+++ b/interpreter/cling/.travis.yml
@@ -72,7 +72,7 @@ matrix:
 
     - os: osx
       env: COMPILER=g++-7 CCOMPILER=gcc-7
-      addon:
+      addons:
         homebrew:
           packages:
           - gcc@7

--- a/tmva/tmva/inc/TMVA/OptimizeConfigParameters.h
+++ b/tmva/tmva/inc/TMVA/OptimizeConfigParameters.h
@@ -40,6 +40,8 @@
 
 #include "TH1.h"
 
+class TestOptimizeConfigParameters;
+
 namespace TMVA {
 
    class MethodBase;
@@ -47,6 +49,7 @@ namespace TMVA {
    class OptimizeConfigParameters : public IFitterTarget  {
 
    public:
+      friend TestOptimizeConfigParameters;
 
       //default constructor
       OptimizeConfigParameters(MethodBase * const method, std::map<TString,TMVA::Interval*> tuneParameters, TString fomType="Separation", TString optimizationType = "GA");

--- a/tmva/tmva/src/CrossValidation.cxx
+++ b/tmva/tmva/src/CrossValidation.cxx
@@ -410,6 +410,7 @@ void TMVA::CrossValidation::ParseOptions()
    fOutputFactoryOptions += Form("AnalysisType=%s:", fAnalysisTypeStr.Data());
 
    if (not fDrawProgressBar) {
+      fCvFactoryOptions += "!DrawProgressBar:";
       fOutputFactoryOptions += "!DrawProgressBar:";
    }
 
@@ -419,27 +420,25 @@ void TMVA::CrossValidation::ParseOptions()
    }
 
    if (fCorrelations) {
-      // fCvFactoryOptions += "Correlations:";
+      fCvFactoryOptions += "Correlations:";
       fOutputFactoryOptions += "Correlations:";
    } else {
-      // fCvFactoryOptions += "!Correlations:";
+      fCvFactoryOptions += "!Correlations:";
       fOutputFactoryOptions += "!Correlations:";
    }
 
    if (fROC) {
-      // fCvFactoryOptions += "ROC:";
+      fCvFactoryOptions += "ROC:";
       fOutputFactoryOptions += "ROC:";
    } else {
-      // fCvFactoryOptions += "!ROC:";
+      fCvFactoryOptions += "!ROC:";
       fOutputFactoryOptions += "!ROC:";
    }
 
    if (fSilent) {
-      // fCvFactoryOptions += Form("Silent:");
+      fCvFactoryOptions += Form("Silent:");
       fOutputFactoryOptions += Form("Silent:");
    }
-
-   fCvFactoryOptions += "!Correlations:!ROC:!Color:!DrawProgressBar";
 
    // CE specific options
    if (fFoldFileOutput and fOutputFile == nullptr) {

--- a/tmva/tmva/src/CrossValidation.cxx
+++ b/tmva/tmva/src/CrossValidation.cxx
@@ -439,7 +439,7 @@ void TMVA::CrossValidation::ParseOptions()
       fOutputFactoryOptions += Form("Silent:");
    }
 
-   fCvFactoryOptions += "!Correlations:!ROC:!Color:!DrawProgressBar:Silent";
+   fCvFactoryOptions += "!Correlations:!ROC:!Color:!DrawProgressBar";
 
    // CE specific options
    if (fFoldFileOutput and fOutputFile == nullptr) {

--- a/tmva/tmva/src/CrossValidation.cxx
+++ b/tmva/tmva/src/CrossValidation.cxx
@@ -516,8 +516,8 @@ TMVA::CrossValidationFoldResult TMVA::CrossValidation::ProcessFold(UInt_t iFold,
 
    if (fFoldFileOutput and fOutputFile != nullptr) {
       TString path = std::string("") + gSystem->DirName(fOutputFile->GetName()) + "/" + foldTitle + ".root";
-      std::cout << "PATH: " << path << std::endl;
       foldOutputFile = TFile::Open(path, "RECREATE");
+      Log() << kINFO << "Creating fold output at:" << path << Endl;
       fFoldFactory = std::make_unique<TMVA::Factory>(fJobName, foldOutputFile, fCvFactoryOptions);
    }
 
@@ -603,7 +603,12 @@ void TMVA::CrossValidation::Evaluate()
       }
 
       TMVA::MsgLogger::EnableOutput();
-      Log() << kINFO << "Evaluate method: " << methodTitle << Endl;
+      Log() << kINFO << Endl;
+      Log() << kINFO << Endl;
+      Log() << kINFO << "========================================" << Endl;
+      Log() << kINFO << "Processing folds for method " << methodTitle << Endl;
+      Log() << kINFO << "========================================" << Endl;
+      Log() << kINFO << Endl;
 
       // Process K folds
       auto nWorkers = fNumWorkerProcs;
@@ -650,6 +655,13 @@ void TMVA::CrossValidation::Evaluate()
 
       method->fEventToFoldMapping = fSplit->fEventToFoldMapping;
    }
+
+   Log() << kINFO << Endl;
+   Log() << kINFO << Endl;
+   Log() << kINFO << "========================================" << Endl;
+   Log() << kINFO << "Folds processed for all methods, evaluating." << Endl;
+   Log() << kINFO << "========================================" << Endl;
+   Log() << kINFO << Endl;
 
    // Recombination of data (making sure there is data in training and testing trees).
    fDataLoader->RecombineKFoldDataSet(*fSplit);

--- a/tmva/tmva/src/OptimizeConfigParameters.cxx
+++ b/tmva/tmva/src/OptimizeConfigParameters.cxx
@@ -358,12 +358,20 @@ Double_t TMVA::OptimizeConfigParameters::GetFOM()
    }else{
       if      (fFOMType == "Separation")  fom = GetSeparation();
       else if (fFOMType == "ROCIntegral") fom = GetROCIntegral();
-      else if (fFOMType == "SigEffAtBkgEff01")  fom = GetSigEffAtBkgEff(0.1);
-      else if (fFOMType == "SigEffAtBkgEff001") fom = GetSigEffAtBkgEff(0.01);
-      else if (fFOMType == "SigEffAtBkgEff002") fom = GetSigEffAtBkgEff(0.02);
-      else if (fFOMType == "BkgRejAtSigEff05")  fom = GetBkgRejAtSigEff(0.5);
-      else if (fFOMType == "BkgEffAtSigEff05")  fom = GetBkgEffAtSigEff(0.5);
-      else {
+      else if (fFOMType.BeginsWith("SigEffAtBkgEff0")){
+         TString percent=TString(fFOMType(14,fFOMType.Sizeof())); //Strip down to number
+         //Support users giving a fraction and old formatting, both cases must start with a 0
+         if (!percent.CountChar('.')) percent.Insert(1,".");
+         fom = GetSigEffAtBkgEff(percent.Atof());
+      }else if (fFOMType.BeginsWith("BkgRejAtSigEff0")){
+         TString percent=TString(fFOMType(14,fFOMType.Sizeof())); 
+         if (!percent.CountChar('.')) percent.Insert(1,".");
+         fom = GetBkgRejAtSigEff(percent.Atof());
+      }else if (fFOMType.BeginsWith("BkgEffAtSigEff0")){
+         TString percent=TString(fFOMType(14,fFOMType.Sizeof())); 
+         if (!percent.CountChar('.')) percent.Insert(1,".");
+         fom = GetBkgEffAtSigEff(percent.Atof());
+      }else {
          Log()<<kFATAL << " ERROR, you've specified as Figure of Merit in the "
               << " parameter optimisation " << fFOMType << " which has not"
               << " been implemented yet!! ---> exit " << Endl;

--- a/tmva/tmva/src/OptimizeConfigParameters.cxx
+++ b/tmva/tmva/src/OptimizeConfigParameters.cxx
@@ -365,7 +365,7 @@ Double_t TMVA::OptimizeConfigParameters::GetFOM()
       }
    };
 
-   Double_t fom=0;
+   Double_t fom = 0;
    if (fMethod->DoRegression()){
       std::cout << " ERROR: Sorry, Regression is not yet implement for automatic parameter optimisation"
                 << " --> exit" << std::endl;
@@ -382,6 +382,7 @@ Double_t TMVA::OptimizeConfigParameters::GetFOM()
               << " been implemented yet!! ---> exit " << Endl;
       }
    }
+
    fFOMvsIter.push_back(fom);
    //   std::cout << "fom="<<fom<<std::endl; // should write that into a debug log (as option)
    return fom;

--- a/tmva/tmva/test/CMakeLists.txt
+++ b/tmva/tmva/test/CMakeLists.txt
@@ -16,6 +16,9 @@ include_directories(${ROOT_INCLUDE_DIRS})
 ROOT_ADD_GTEST(TestRandomGenerator
                TestRandomGenerator.cxx
                LIBRARIES ${Libraries})
+ROOT_ADD_GTEST(TestOptimizeConfigParameters
+               TestOptimizeConfigParameters.cxx
+               LIBRARIES ${Libraries})
 
 if(dataframe)
     # RTensor

--- a/tmva/tmva/test/TestOptimizeConfigParameters.cxx
+++ b/tmva/tmva/test/TestOptimizeConfigParameters.cxx
@@ -1,0 +1,271 @@
+
+// ROOT
+#include "TRandom3.h"
+
+// TMVA
+#include "TMVA/DataLoader.h"
+#include "TMVA/Factory.h"
+#include "TMVA/Interval.h"
+#include "TMVA/OptimizeConfigParameters.h"
+#include "TMVA/Config.h"
+
+// Stdlib
+#include <iostream>
+
+// External
+#include "gtest/gtest.h"
+
+class TestOptimizeConfigParametersFixture : public ::testing::Test {
+public:
+   TestOptimizeConfigParametersFixture()
+   : fDataloader(GetDataloader()),
+     fFactory(GetFactory()),
+     fMethod(GetMethod(fFactory, fDataloader))
+   {
+      TMVA::MsgLogger::InhibitOutput();
+   }
+
+   TMVA::MethodBase * GetMethod() {return fMethod;}
+
+protected:
+   void SetUp() override {}
+   void TearDown () override {}
+
+   TMVA::DataLoader * GetDataloader()
+   {
+      TRandom3 rng(100);
+
+      auto dl = new TMVA::DataLoader{"Dataloader"};
+      dl->AddVariable("x");
+      for (Int_t n = 0; n < 100; ++n) {
+         dl->AddSignalTrainingEvent({rng.Gaus()+0.1});
+         dl->AddSignalTestEvent({rng.Gaus()+0.1});
+         dl->AddBackgroundTrainingEvent({rng.Gaus()-0.1});
+         dl->AddBackgroundTestEvent({rng.Gaus()-0.1});
+      }
+
+      dl->PrepareTrainingAndTestTree("", "!V");
+
+      return dl;
+   }
+
+   TMVA::Factory * GetFactory()
+   {
+      TMVA::gConfig().SetSilent(true);
+      return new TMVA::Factory{"", "!V:Silent:!DrawProgressBar"};
+   }
+
+   TMVA::MethodBase * GetMethod(TMVA::Factory * f,
+                                TMVA::DataLoader * dl)
+   {
+      f->BookMethod(dl, TMVA::Types::kBDT, "BDT",
+                     "!V:NTrees=1:BoostType=Grad:NCuts=10");
+      f->TrainAllMethods();
+      auto * m = f->GetMethod(dl->GetName(), "BDT");
+      return dynamic_cast<TMVA::MethodBase *>(m);
+   }
+
+   TMVA::DataLoader * fDataloader;
+   TMVA::Factory * fFactory;
+   TMVA::MethodBase * fMethod;
+};
+
+/*
+ * This class is a friend class to the unit under test and its main purpose is
+ * to forward calls to private functions.
+ *
+ * It also provides a static test environment so that the creation of dataset
+ * and any potetial shared operations (e.g. training) is executed only once
+ * for all tests.
+ */
+class TestOptimizeConfigParameters {
+public:
+   TestOptimizeConfigParameters(TString fomType, TMVA::MethodBase * method)
+   :  fOpt(GetOptimiser(fomType, method))
+   {}
+
+   Double_t GetFOM() {
+      return fOpt.GetFOM();
+   }
+
+   Double_t GetSigEffAtBkgEff(double x) {
+      return fOpt.GetSigEffAtBkgEff(x);
+   }
+
+   Double_t GetBkgRejAtSigEff(double x) {
+      return fOpt.GetBkgRejAtSigEff(x);
+   }
+
+   Double_t GetBkgEffAtSigEff(double x) {
+      return fOpt.GetBkgEffAtSigEff(x);
+   }
+
+private:
+   TMVA::OptimizeConfigParameters GetOptimiser(TString fomType, TMVA::MethodBase * method)
+   {
+      std::map<TString, TMVA::Interval *> params{};
+      params.insert(std::pair<TString, TMVA::Interval *>("NTrees", new TMVA::Interval(10, 1000, 5)));
+      return TMVA::OptimizeConfigParameters(method, params, fomType);
+   }
+
+   TMVA::OptimizeConfigParameters fOpt;
+};
+
+
+TEST_F(TestOptimizeConfigParametersFixture, FOM_SigEffAtBkgEff)
+{
+   {   
+      auto opt0 = TestOptimizeConfigParameters("SigEffAtBkgEff0.001", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetSigEffAtBkgEff(0.001));
+
+      auto opt1 = TestOptimizeConfigParameters("SigEffAtBkgEff0001", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetSigEffAtBkgEff(0.001));
+
+      std::cout << "opt0.GetSigEffAtBkgEff(0.001): "
+                << opt0.GetSigEffAtBkgEff(0.001) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("SigEffAtBkgEff0.01", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetSigEffAtBkgEff(0.01));
+
+      auto opt1 = TestOptimizeConfigParameters("SigEffAtBkgEff001", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetSigEffAtBkgEff(0.01));
+
+      std::cout << "opt0.GetSigEffAtBkgEff(0.01): "
+                << opt0.GetSigEffAtBkgEff(0.01) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("SigEffAtBkgEff0.1", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetSigEffAtBkgEff(0.1));
+
+      auto opt1 = TestOptimizeConfigParameters("SigEffAtBkgEff01", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetSigEffAtBkgEff(0.1));
+
+      std::cout << "opt0.GetSigEffAtBkgEff(0.1): "
+                << opt0.GetSigEffAtBkgEff(0.1) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("SigEffAtBkgEff0.5", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetSigEffAtBkgEff(0.5));
+
+      auto opt1 = TestOptimizeConfigParameters("SigEffAtBkgEff05", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetSigEffAtBkgEff(0.5));
+
+      std::cout << "opt0.GetSigEffAtBkgEff(0.5): "
+                << opt0.GetSigEffAtBkgEff(0.5) << std::endl;
+   }
+
+
+   // auto opt = TestOptimizeConfigParameters("SigEffAtBkg1", GetMethod());
+   // auto opt = TestOptimizeConfigParameters("SigEffAtBkg10", GetMethod());
+   // Expect crash
+}
+
+
+TEST_F(TestOptimizeConfigParametersFixture, FOM_BkgRejAtSigEff)
+{
+   {   
+      auto opt0 = TestOptimizeConfigParameters("BkgRejAtSigEff0.001", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgRejAtSigEff(0.001));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgRejAtSigEff0001", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgRejAtSigEff(0.001));
+
+      std::cout << "opt0.GetBkgRejAtSigEff(0.001): "
+                << opt0.GetBkgRejAtSigEff(0.001) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("BkgRejAtSigEff0.01", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgRejAtSigEff(0.01));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgRejAtSigEff001", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgRejAtSigEff(0.01));
+
+      std::cout << "opt0.GetBkgRejAtSigEff(0.01): "
+                << opt0.GetBkgRejAtSigEff(0.01) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("BkgRejAtSigEff0.1", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgRejAtSigEff(0.1));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgRejAtSigEff01", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgRejAtSigEff(0.1));
+
+      std::cout << "opt0.GetBkgRejAtSigEff(0.1): "
+                << opt0.GetBkgRejAtSigEff(0.1) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("BkgRejAtSigEff0.5", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgRejAtSigEff(0.5));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgRejAtSigEff05", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgRejAtSigEff(0.5));
+
+      std::cout << "opt0.GetBkgRejAtSigEff(0.5): "
+                << opt0.GetBkgRejAtSigEff(0.5) << std::endl;
+   }
+
+
+   // auto opt = TestOptimizeConfigParameters("BkgRejAtSigEff1", GetMethod());
+   // auto opt = TestOptimizeConfigParameters("BkgRejAtSigEff10", GetMethod());
+   // Expect crash
+}
+
+
+TEST_F(TestOptimizeConfigParametersFixture, FOM_BkgEffAtSigEff)
+{
+   {   
+      auto opt0 = TestOptimizeConfigParameters("BkgEffAtSigEff0.001", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgEffAtSigEff(0.001));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgEffAtSigEff0001", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgEffAtSigEff(0.001));
+
+      std::cout << "opt0.GetBkgEffAtSigEff(0.001): "
+                << opt0.GetBkgEffAtSigEff(0.001) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("BkgEffAtSigEff0.01", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgEffAtSigEff(0.01));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgEffAtSigEff001", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgEffAtSigEff(0.01));
+
+      std::cout << "opt0.GetBkgEffAtSigEff(0.01): "
+                << opt0.GetBkgEffAtSigEff(0.01) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("BkgEffAtSigEff0.1", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgEffAtSigEff(0.1));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgEffAtSigEff01", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgEffAtSigEff(0.1));
+
+      std::cout << "opt0.GetBkgEffAtSigEff(0.1): "
+                << opt0.GetBkgEffAtSigEff(0.1) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("BkgEffAtSigEff0.5", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgEffAtSigEff(0.5));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgEffAtSigEff05", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgEffAtSigEff(0.5));
+
+      std::cout << "opt0.GetBkgEffAtSigEff(0.5): "
+                << opt0.GetBkgEffAtSigEff(0.5) << std::endl;
+   }
+
+
+   // auto opt = TestOptimizeConfigParameters("BkgEffAtSigEff1", GetMethod());
+   // auto opt = TestOptimizeConfigParameters("BkgEffAtSigEff10", GetMethod());
+   // Expect crash
+}

--- a/tutorials/tmva/TMVAClassification.C
+++ b/tutorials/tmva/TMVAClassification.C
@@ -527,7 +527,7 @@ int TMVAClassification( TString myMethodList = "" )
    //  Now you can optimize the setting (configuration) of the MVAs using the set of training events
    // STILL EXPERIMENTAL and only implemented for BDT's !
    //
-   //     factory->OptimizeAllMethods("SigEffAt001","Scan");
+   //     factory->OptimizeAllMethods("SigEffAtBkg0.01","Scan");
    //     factory->OptimizeAllMethods("ROCIntegral","FitGA");
    //
    // --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
cc @smuzaffar, @davidlange6, @Axel-Naumann

"@smuzaffar we'll need your help to know what to do, based on realistic numbers. We would very much appreciate if you could compare:

   * a ROOT build without modules, and with this PR (i.e. without rdict.pcm files),
   * compared to a ROOT build without modules (still!), without this PR (i.e. with rdict.pcm files)

I.e. always non-modularized ROOT, with vs without this PR.

We're interested in the change in RSS and real time, for a reco on say a single event with a small event size, e.g. minbias. Do you think you could help us with this?"