### PR TITLE
TClass::GetListOfDataMembers reload list for struct/class when needed.

### DIFF
--- a/core/meta/inc/TListOfDataMembers.h
+++ b/core/meta/inc/TListOfDataMembers.h
@@ -32,12 +32,13 @@ class TDataMember;
 class TListOfDataMembers : public THashList
 {
 private:
-   TClass    *fClass = nullptr;    //! Context of this list.  Not owned.
+   TClass           *fClass = nullptr;    //! Context of this list.  Not owned.
 
-   TExMap    *fIds = nullptr;      //! Map from DeclId_t to TDataMember*
-   THashList *fUnloaded = nullptr; //! Holder of TDataMember for unloaded DataMembers.
-   ULong64_t  fLastLoadMarker = 0; //! Represent interpreter state when we last did a full load.
-   Bool_t     fIsLoaded = kFALSE;  //! Mark whether Load was executed.
+   TExMap           *fIds = nullptr;      //! Map from DeclId_t to TDataMember*
+   THashList        *fUnloaded = nullptr; //! Holder of TDataMember for unloaded DataMembers.
+   ULong64_t         fLastLoadMarker = 0; //! Represent interpreter state when we last did a full load.
+   std::atomic<bool> fIsLoaded{kFALSE};  //! Mark whether Load was executed.
+
    TDictionary::EMemberSelection fSelection = TDictionary::EMemberSelection::kNoUsingDecls; //! Whether the list should contain regular data members or only using decls or both.
 
    TListOfDataMembers(const TListOfDataMembers&) = delete;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3733,7 +3733,11 @@ TList *TClass::CreateListOfDataMembers(std::atomic<TListOfDataMembers*> &data, T
 TList *TClass::GetListOfDataMembers(Bool_t load /* = kTRUE */)
 {
    // Fast path, no lock? Classes load at creation time.
-   if ((!load || IsClassStructOrUnion()) && fData)
+   if (IsClassStructOrUnion()) {
+      auto data = fData.load();
+      if (data && data->IsLoaded())
+         return data;
+   } else if (!load && fData)
       return fData;
 
    return CreateListOfDataMembers(fData, TDictionary::EMemberSelection::kNoUsingDecls, load);


### PR DESCRIPTION
The problem was due  the introduction (in commit f3f0f13) of a fast path in TClass::GetListOfDataMember which did not take in consideration the case:

c = GetClass(someclassname)
c->GetState() == TClass::kForwardDeclared
c->GetListOfDataMember() -> list is now created but empty.
load and parse header file for
c->GetState() == TClass::kInterpreted
c->GetListOfDataMember() -> list is still empty but should have been filled (loaded at this point).

The logic assumed incorrectly that if someclassname was indeed pointing to a class or struct and the list was created then it was loaded.

To keep the fast path and correct the logic, we need to 'promote' TListOfDataMembers::fIsLoaded to be an std::atomic