### PR TITLE
In TStreamerInfo::GenerateInfoForPair use a non-zero size enums.

### DIFF
--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -5588,15 +5588,18 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
       }
       TClass *clm = TClass::GetClass(dmType);
       if (!clm) {
-         if (TEnum::GetEnum(dmType, TEnum::kNone)) {
-            Int_t dtype = kInt_t;
-            return new TStreamerBasicType(dmName,dmTitle,offset,dtype,dmFull.c_str());
+         auto enumdesc = TEnum::GetEnum(dmType, TEnum::kNone);
+         if (enumdesc) {
+            auto dtype = enumdesc->GetUnderlyingType();
+            auto el = new TStreamerBasicType(dmName, dmTitle, offset, dtype, dmFull.c_str());
+            auto datatype = TDataType::GetDataType(dtype);
+            if (datatype)
+               el->SetSize(datatype->Size());
+            else
+               el->SetSize(sizeof(int)); // Default size of enums.
+            return el;
          }
          return nullptr;
-         // either we have an Emulated enum or a really unknown class!
-         // let's just claim its an enum :(
-         //Int_t dtype = kInt_t;
-         //return new TStreamerBasicType(dmName,dmTitle,offset,dtype,dmFull.c_str());
       }
       // a pointer to a class
       if ( dmIsPtr ) {


### PR DESCRIPTION
This fix #6726

As reported by CMSSW tests (for example: cms-sw/cmsdist#6314 (comment)) where the data appear odd/corrupted, there is an issue in TStreamerInfo::GenerateInfoForPair (which is almost always used for std::pair in the tip of v6.22 and master).

The problem is when calculating the offset of the second data member, TStreamerInfo::GenerateInfoForPair uses (unwittingly, of course :) ), the value zero for the size of the enums.

to test with existing root 622 (no new commits available)