### PR TITLE
[cling] LookupHelper must not unload Transactions:

### DIFF
--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -722,7 +722,11 @@ namespace cling {
                         // in invalid state. We should be unloading all of them, i.e. inload the
                         // current (possibly nested) transaction.
                         auto *T = const_cast<Transaction*>(m_Interpreter->getCurrentTransaction());
-                        m_Interpreter->unload(*T);
+                        // Must not unload the Transaction, which might delete
+                        // it: the RAII above still points to it! Instead, just
+                        // mark it as "erroneous" which causes the RAII to
+                        // unload it in due time.
+                        T->setIssuedDiags(Transaction::kErrors);
                         *setResultType = nullptr;
                         return 0;
                       }


### PR DESCRIPTION
Outer RAIIs might still reference the Transaction, and unload is
assuming that it owns the transaction and can delete it / put it
into the TransactionPool.

This fixes https://github.com/root-project/root/issues/7657

We still need to track ownership as what has happened here (unload
of a Transaction held by an RAII) can happen again / elsewhere.
This will be addressed by a subsequent PR in master.

(cherry picked from commit 0202a4b065b0a9d8116f1c42af9a0eebad570401)