### PR TITLE
[AArch64] Materialize FP constant in code for large code model

### DIFF
--- a/interpreter/llvm/src/lib/Target/AArch64/AArch64FastISel.cpp
+++ b/interpreter/llvm/src/lib/Target/AArch64/AArch64FastISel.cpp
@@ -414,8 +414,8 @@ unsigned AArch64FastISel::materializeFP(const ConstantFP *CFP, MVT VT) {
     return fastEmitInst_i(Opc, TLI.getRegClassFor(VT), Imm);
   }
 
-  // For the MachO large code model materialize the FP constant in code.
-  if (Subtarget->isTargetMachO() && TM.getCodeModel() == CodeModel::Large) {
+  // For the large code model materialize the FP constant in code.
+  if (TM.getCodeModel() == CodeModel::Large) {
     unsigned Opc1 = Is64Bit ? AArch64::MOVi64imm : AArch64::MOVi32imm;
     const TargetRegisterClass *RC = Is64Bit ?
         &AArch64::GPR64RegClass : &AArch64::GPR32RegClass;


### PR DESCRIPTION
Backport of D99607

Original commit message:
---
When using the large code model with FastISel (for example via
clang -O0 which adds the optnone attribute), FP constants could
still be materialized using adrp + ldr. Unconditionally enable
the existing path for MachO to materialize the constant in code.

[...]
---

See the discussion in https://github.com/cms-sw/cmssw/issues/31123
for context on the observed crashes.