### PR TITLE
Do not alter the llvm::Module when running the static inits.

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
@@ -275,10 +275,6 @@ IncrementalExecutor::runStaticInitializersOnce(Transaction& T) {
   llvm::ConstantArray *InitList
     = llvm::dyn_cast<llvm::ConstantArray>(GV->getInitializer());
 
-  // We need to delete it here just in case we have recursive inits, otherwise
-  // it will call inits multiple times.
-  GV->eraseFromParent();
-
   if (InitList == 0)
     return kExeSuccess;
 

--- a/interpreter/cling/test/Prompt/RecursiveGlobalInits.C
+++ b/interpreter/cling/test/Prompt/RecursiveGlobalInits.C
@@ -17,4 +17,21 @@ class MyClass { public:  MyClass(){ gCling->process("gCling->getVersion()");} };
 
 MyClass *My = new MyClass(); // CHECK: (const char *) "{{.*}}"
 
+extern "C" int printf(const char*...);
+
+struct S {
+  S() {
+    printf("Exec\n");
+    gCling->process("printf(\"RecursiveExec\\n\");");
+  }
+} s;
+// CHECK-NEXT:Exec
+// CHECK-NEXT:RecursiveExec
+gCling->process("int RecursiveInit = printf(\"A\\n\");");
+int ForceInitSequence = 17;
+
+// CHECK-NEXT:A
+
+// CHECK-EMPTY:
+
 .q


### PR DESCRIPTION
This change was from MCJIT times and now is not needed anymore. Moreover, the
orcv2 jit infrastructure considers the llvm::Module immutable after it takes
control of it via emitModule. This change will allow us to migrate easier to
orcv2.