### PR TITLE
[WIP] Complain about invalid sources again

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
@@ -1497,7 +1497,7 @@ bool ASTReader::ReadSLocEntry(int ID) {
     // We will detect whether a file changed and return 'Failure' for it, but
     // we will also try to fail gracefully by setting up the SLocEntry.
     unsigned InputID = Record[4];
-    InputFile IF = getInputFile(*F, InputID, /*Complain=*/false);
+    InputFile IF = getInputFile(*F, InputID);
     const FileEntry *File = IF.getFile();
     bool OverriddenBuffer = IF.isOverridden();
 


### PR DESCRIPTION
This used to be a local ROOT patch of Clang
(https://github.com/vgvassilev/clang/commit/a5ee33ae48)
However, after trying to upstream it, there're two tests broken:

* Modules/module-file-modified.c
* Modules/explicit-build-missing-files.cpp

I have talked with Vassil briefly and he said this change has something
to do with virtual files. Let's try to revert this and see how ROOT's
tests break. Ideally we'll find a more appropriate approach.