### PR TITLE
Drop llvm::GlobalValue in DeferredDeclsToEmit

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/CodeGen/CodeGenModule.h
+++ b/interpreter/llvm/src/tools/clang/lib/CodeGen/CodeGenModule.h
@@ -362,15 +362,9 @@ private:
 
   /// This is a list of deferred decls which we have seen that *are* actually
   /// referenced. These get code generated when the module is done.
-  struct DeferredGlobal {
-    DeferredGlobal(llvm::GlobalValue *GV, GlobalDecl GD) : GV(GV), GD(GD) {}
-    llvm::TrackingVH<llvm::GlobalValue> GV;
-    GlobalDecl GD;
-  };
-  std::vector<DeferredGlobal> DeferredDeclsToEmit;
-  void addDeferredDeclToEmit(llvm::GlobalValue *GV, GlobalDecl GD,
-                             StringRef MangledName) {
-    DeferredDeclsToEmit.emplace_back(GV, GD);
+  std::vector<GlobalDecl> DeferredDeclsToEmit;
+  void addDeferredDeclToEmit(GlobalDecl GD, StringRef MangledName) {
+    DeferredDeclsToEmit.emplace_back(GD);
     addEmittedDeferredDecl(GD, MangledName);
   }
 

--- a/interpreter/llvm/src/tools/clang/lib/CodeGen/ModuleBuilder.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/CodeGen/ModuleBuilder.cpp
@@ -195,8 +195,7 @@ namespace clang {
       out << " DeferredDeclsToEmit (std::vector<DeferredGlobal>)\n";
       for(auto I = Builder->DeferredDeclsToEmit.begin(),
             E = Builder->DeferredDeclsToEmit.end(); I != E; ++I) {
-        I->GD.getDecl()->print(out);
-        I->GV->print(out);
+        I->getDecl()->print(out);
         out << "\n";
       }
 


### PR DESCRIPTION
The previous cling patches wraps `DeferredDeclsToEmit(vector<GlobalDecl>)`
into a struct that contains a `llvm::GlobalVlaue`, but it seems that this
field is useless and can be droped. I have tested this patch in Cling and
spotted no new tests failing, so let's give ROOT a try.

Signed-off-by: Jun Zhang <jun@junz.org>