### PR TITLE
[TCling] Fix suppression of enum forward declarations

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -2194,8 +2194,10 @@ void TCling::RegisterModule(const char* modulename,
                   }
                }
                if (scopes.empty() || DC) {
-                  // We know the scope; let's look for the enum.
-                  size_t posEnumName = fwdDeclsLine.find("\"))) ", 32);
+                  // We know the scope; let's look for the enum. For that, look
+                  // for the *last* closing parentheses of an attribute because
+                  // there can be multiple.
+                  size_t posEnumName = fwdDeclsLine.rfind("\"))) ");
                   R__ASSERT(posEnumName != std::string::npos && "Inconsistent enum fwd decl!");
                   posEnumName += 5; // skip "\"))) "
                   while (isspace(fwdDeclsLine[posEnumName]))


### PR DESCRIPTION
There can be multiple attributes in the forward declaration, see the added test in roottest/cling/dict/enum (reduced from a case reported by CMS in https://github.com/cms-sw/cmssw/issues/42234), so we have to look for the last closing parentheses.

(cherry picked from commit 9d2f7612a6e88d3a7148b19e131402349bac509b)